### PR TITLE
Use explicit target "/" for header logo homepage link.

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -8,7 +8,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="{{ site.baseurl }}"><img alt="WebRTC logo" src="{{ site.baseurl }}/assets/images/webrtc-logo-horiz-retro-243x40.png" style="margin-top: -2px;"></a>
+        <a class="navbar-brand" href="/"><img alt="WebRTC logo" src="{{ site.baseurl }}/assets/images/webrtc-logo-horiz-retro-243x40.png" style="margin-top: -2px;"></a>
       </div>
 
       <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
In production, there's no special need to use
`site.baseurl` as the target for the header logo
homepage link, as it's not dynamic.

There's also no need in the case of a local dev
server, provided a host like `localhost` is used.

`site.baseurl` would only be needed in the case
of serving from a gh-pages project site, where URL
paths are offset from the docroot, e.g., /webrtc-org

We don't care about that case. Fixes #15.
