### PR TITLE
Sync old site prerequisites

### DIFF
--- a/bugs/index.md
+++ b/bugs/index.md
@@ -10,51 +10,98 @@ crumb: Reporting Bugs
 
 There are a couple bug trackers relevant to WebRTC:
 
-  * [crbug.com](http://crbug.com) - for Chrome.
+  * [crbug.com](https://crbug.com) -- for Chrome.\*
 
-  * [bugzilla.mozilla.org](https://bugzilla.mozilla.org/) - for Firefox.
+  * [bugzilla.mozilla.org](https://bugzilla.mozilla.org/) -- for Firefox.
 
-  * [bugs.opera.com/wizard](https://bugs.opera.com/wizard/) - for Opera.
+  * [bugs.opera.com/wizard](https://bugs.opera.com/wizard/) -- for Opera.
 
-  * [bugs.webrtc.org](http://bugs.webrtc.org) - for WebRTC native code.
+  * [bugs.webrtc.org](http://bugs.webrtc.org) -- for WebRTC native code.
+
+\* Anyone with a [Google account][1] can file bugs and they're continuously
+triaged by Chrome and WebRTC engineers.
+
 
 ### How to File a Good Bug Report
 
-It's important a bug report contains the relevant information in order to get
-it fixed.
+Please include as many relevant details as possible.
 
 
 #### Example Data Points
 
-  * Version of the browser/app (check [chrome://version] for Chrome)
-  * Operating system (Windows, Mac, Linux, Android, iOS etc) and version
-    (Windows 7, OS X 10.9, Ubuntu 14 etc.)
-  * Hardware platform/device model (PC, Mac, Samsung 4S, Nexus 7, iPhone 5S,
-    iPad Air 2 etc)
-  * Webcam model and version (if applicable)
-  * Web site URL
-  * Reproduction steps: detailed information on how to reproduce the bug. If
-    applicable and possible: a minimal test page in HTML+JavaScript.
+  * Version of the browser/app
 
-[chrome://version]: chrome://version
+    * For Chrome: copy/paste from **chrome://version**
+
+    * For WebRTC native code: if applicable, include the branch (e.g. trunk)
+      and WebRTC revision (e.g. r8207) your application uses
+
+  * Operating system (Windows, Mac, Linux, Android, iOS, etc.) and version
+    (e.g. Windows 7, OS X 10.9, Ubuntu 14, etc.)
+
+  * Hardware platform/device model (e.g. PC, Mac, Samsung 4S, Nexus 7, iPhone
+    5S, iPad Air 2 etc)
+
+  * Camera and microphone model and version (if applicable)
+
+    * <p>For Chrome audio and video device issues, please run the tests at
+      <https://test.webrtc.org>. After the tests finish running, click the bug
+      icon at the top, download the report, and attach the report to the issue
+      tracker.</p>
+
+  * Web site URL
+
+  * Reproduction steps: detailed information on how to reproduce the bug. If
+    applicable, please either attach or link to a minimal test page in
+    HTML+JavaScript.
+
+  * For **crashes**
+
+    * If you experience a crash while using Chrome, please include a crash ID
+      by following [these instructions][2].
+
+    * If you experience a crash while using WebRTC native code, please include
+      the full stacktrace.
+
+  * For **connectivity** issues on Chrome, while the call is in progress,
+
+    * please open **chrome://webrtc-internals** in another tab,
+
+    * expand the **Create Dump** section,
+
+    * click the **Download the PeerConnection updates and stats data** button.
+      You will be prompted to save the dump to your local machine. Please
+      attach that dump to the bug report.
+
+  * For **audio quality** issues on Chrome, while the call is in progress,
+
+    * please open **chrome://webrtc-internals** in another tab,
+
+    * expand the **Create Dump** section,
+
+    * fill in the **Enable diagnostic audio recordings** checkbox. You will be
+      prompted to save the recording to your local machine. After ending the
+      call, attach the recording to the bug.
+
+  * For **echo** issues, please try to capture an audio recording from the
+    side that is _generating_ the echo, not the side that _hears_ the echo.
+    For example, if UserA and UserB are in a call, and UserA hears herself
+    speak, please obtain an audio recording from UserB.
 
 
 #### Instructions
 
-  1. Identify which bug tracker to use:
+  * Identify which bug tracker to use:
 
-     * If you're hitting a problem in Chrome, file the bug using the
-       Audio/Video Issue template.
+    * If you're hitting a problem in Chrome, file the bug using the
+      [Audio/Video Issue template][3].
 
-     * If you're a developer working with the native code, file the bug at
-       this link.
+    * If you're a developer working with the native code, file the bug at
+      [this link][4].
 
-  2. Include as much as possible from the data points listed above. You can
-     use <//test.webrtc.org> and attach the log for some of this data.
+  * Include as much as possible from the data points listed above.
 
-  3. If possible; include a dump from chrome://webrtc-internals (must be done
-     during the WebRTC session).
-
-     * If your bug is related to audio quality; check the Enable diagnostic
-       audio recordings checkbox to create a recording.
-
+[1]: https://accounts.google.com/
+[2]: http://www.chromium.org/for-testers/bug-reporting-guidelines/reporting-crash-bug
+[3]: https://code.google.com/p/chromium/issues/entry?template=Audio/Video%20Issue
+[4]: https://code.google.com/p/webrtc/issues/entry

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -84,8 +84,8 @@ contributor agreements
   * [Individual Contributors License][1]
   * [Corporate Contributors License][2]
 
-[1]: https://developers.google.com/open-source/cla/individual
-[2]: https://developers.google.com/open-source/cla/corporate
+[1]: https://cla.developers.google.com/about/google-individual
+[2]: https://cla.developers.google.com/about/google-corporate
 
 Also, please re-read our project's
 [license]({{ site.baseurl}}/license/software/) and

--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -30,23 +30,29 @@ Android development is only supported on Linux.
   4. Create a working directory, enter it, and run:
 
      ~~~~~ bash
-     fetch webrtc_android
+     fetch --nohooks webrtc_android
+     gclient sync
      ~~~~~
 
-See Development for instructions on how to update the code, building etc.
+This will fetch a regular WebRTC checkout with the Android-specific parts
+added. The same checkout can be used for both Linux and Android development,
+depending on the OS you set in `GYP_DEFINES` (see above).
+
+See [Development](/native-code/development/) for instructions on how to update
+the code, building etc.
 
 
 ### Using the Bundled Android SDK/NDK
 
 In order to use the Android SDK and NDK that is bundled in
-third_party/android_tools, run this to get it included in your PATH (from
-src/):
+`third_party/android_tools`, run this to get it included in your `PATH` (from
+`src/`):
 
 ~~~~~ bash
 . build/android/envsetup.sh
 ~~~~~
 
-Then you'll have adb and all the other Android tools in your PATH.
+Then you'll have `adb` and all the other Android tools in your `PATH`.
 
 
 ### Running the AppRTCDemo App
@@ -94,8 +100,33 @@ To build APKs with the WebRTC native tests, follow these instructions.
      webrtc/build/android/test_runner.py gtest -s modules_unittests
      ~~~~~
 
-  5. **NOTICE:** The first time you run a test, you must accept a dialog on
+  5. If want to run a Release build, add `--release` to the command line
+     above.
+
+     If you want to limit to a subset of tests, use the `--gtest_filter flag`,
+     e.g.
+
+     ~~~~~
+     webrtc/build/android/test_runner.py gtest -s modules_unittests \
+     --gtest_filter=RtpRtcpAPITest.SSRC:RtpRtcpRtcpTest.*
+     ~~~~~
+
+  6. **NOTICE:** The first time you run a test, you must accept a dialog on
      the device!
+
+  7. **NOTICE:** If you run large test suites (like `webrtc_perf_tests` and
+     `modules_unittests`) without any test filter, you may need to pass the
+     `-t` flag to the script to set a higher timeout than the default 60
+     seconds. 1800 seconds is needed for `webrtc_perf_tests` on slower
+     devices.
+
+
+### Running WebRTC Instrumentation Tests on an Android Device
+
+To run the instrumentation tests (like AppRTCDemoTest and
+libjingle_peerconnection_android_unittest), use the `instrumentation` command
+for `test_runner.py` instead of `gtest`.
+
 
 [1]: {{ site.baseurl }}/native-code/development/prerequisite-sw/
 [2]: https://chromium.googlesource.com/external/webrtc/+/master/talk/app/webrtc/java/README

--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -29,14 +29,15 @@ For desktop development:
      export JAVA_HOME=<location of OpenJDK 7>
      ~~~~~
 
-  2. On Windows: launch a command prompt as Administrator.
+  2. On Windows, launch a command prompt as Administrator.
 
   3. Create a working directory, enter it, and run `fetch webrtc`:
 
      ~~~~~ bash
      mkdir webrtc-checkout
      cd webrtc-checkout
-     fetch webrtc
+     fetch --nohooks webrtc
+     gclient sync
      ~~~~~
 
      This will **take a long time** because it downloads the whole Chromium
@@ -75,7 +76,7 @@ git pull
 **Notice:** if you're not on a branch, `git pull` won't work, and you'll need
 to use `git fetch` instead.
 
-Peridically, the build toolchain and dependencies of WebRTC are updated. To
+Periodically, the build toolchain and dependencies of WebRTC are updated. To
 get such updates you must run:
 
 ~~~~~ bash
@@ -187,7 +188,7 @@ To create a local branch tracking a remote release branch (in this example,
 the 43 branch):
 
 ~~~~~ bash
-git checkout -b my_branch branch-heads/43
+git checkout -b my_branch refs/remotes/branch-heads/43
 ~~~~~
 
 Commit log for the branch:
@@ -211,11 +212,11 @@ committing, below.
 
 To commit code you have to be a committer.
 
-From March 24, 2015, the source of truth is the Git repository at
+Since March 24, 2015 the source of truth is the Git repository at
 <https://chromium.googlesource.com/external/webrtc>. To be able to push
 commits to it, you need to perform the steps below.
 
-If you already have a `.netrc` / `.gitcookies` file (most Chromium committers
+If you already have a `.netrc`/`.gitcookies` file (most Chromium committers
 already do), you can skip steps 1 and 2.
 
   1. Go to <https://chromium.googlesource.com/new-password> and login with
@@ -346,13 +347,13 @@ connection can't be established. Can be used with the call application above.
 #### STUN Server
 
 Target name `stunserver`. Implements the STUN protocol for Session Traversal
-Utilities for NAT as documented in RFC5389.
+Utilities for NAT as documented in [RFC 5389].
 
 
 #### TURN Server
 
 Target name `turnserver`. In active development to reach compatibility with
-RFC5766.
+[RFC 5766].
 
 
 [1]: {{ site.baseurl }}/native-code/android/
@@ -366,3 +367,5 @@ RFC5766.
 [9]: {{ site.baseurl }}/contributing/
 [10]: http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
 [11]: {{ site.baseurl }}/native-code/native-apis/
+[RFC 5389]: https://tools.ietf.org/html/rfc5389
+[RFC 5766]: https://tools.ietf.org/html/rfc5766

--- a/native-code/development/prerequisite-sw/index.md
+++ b/native-code/development/prerequisite-sw/index.md
@@ -33,12 +33,12 @@ sync:
 ./build/install-build-deps.sh
 ~~~~~
 
-Pulse Audio is missing from the script. On Ubuntu, this is provided by the
+PulseAudio is missing from the script. On Ubuntu, this is provided by the
 `libpulse-dev` package.
 
-Although the `install-build-deps.sh` script is the recommended method, it will
-install much more than you need. Here is a (hopefully complete) minimal list
-of packages to install (`sudo apt-get install ...`):
+Although the [install-build-deps.sh][1] script is the recommended method, it
+will install much more than you need. Here is a (hopefully complete) minimal
+list of packages to install (`sudo apt-get install ...`):
 
 ~~~~~ bash
 g++ (>= 4.2)
@@ -52,11 +52,16 @@ libgtk2.0-dev
 libexpat1-dev
 ~~~~~
 
-For 32-bit builds on a 64-bit system:
+[1]: https://code.google.com/p/chromium/codesearch#chromium/src/build/install-build-deps.sh
+
+To create 32-bit builds for Linux on a 64-bit system (not needed or Android
+builds):
 
 ~~~~~ bash
 lib32asound2-dev
-ia32-libs
+lib32z1
+lib32ncurses5
+lib32bz2-1.0
 ~~~~~
 
 Tips for other distributions are available on the Chromium page.
@@ -64,17 +69,20 @@ Tips for other distributions are available on the Chromium page.
 
 ### Windows
 
-Follow Chromium's build instructions at <http://www.chromium.org/developers/how-tos/build-instructions-windows>
+Follow Chromium's build instructions at
+<http://www.chromium.org/developers/how-tos/build-instructions-windows>.
 
 
 ### OS X
 
-XCode 3.0 or higher
+Xcode 3.0 or higher
 
 
 ### Android
 
-These instructions are tested on a Linux development machine. In WebRTC, we're using the same Android toolchain as Chrome (the one that is downloaded into third_party/android_tools). So you don't need to install NDK/SDK separately.
+These instructions are tested on a Linux development machine. In WebRTC, we're
+using the same Android toolchain as Chrome (the one that is downloaded into
+`third_party/android_tools`). You don't need to install NDK/SDK separately.
 
   1. Install [Chrome's Linux prerequisites](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions_prerequisites.md)
 

--- a/native-code/index.md
+++ b/native-code/index.md
@@ -6,21 +6,25 @@ crumb: Native Code
 ---
 
 
-The WebRTC Native Code package is meant for browser developers that want to
+The WebRTC Native Code package is meant for browser developers who want to
 integrate WebRTC. Application developers are encouraged to use the [WebRTC
 API](http://dev.w3.org/2011/webrtc/editor/webrtc.html) instead.
 
-The WebRTC native code package can be found at:
+The WebRTC **native code package** can be found at:
 
-<https://chromium.googlesource.com/external/webrtc>
+  * <https://chromium.googlesource.com/external/webrtc>
 
-Please read the [License & Rights]({{ site.baseurl }}/license/) and
-[FAQ]({{ site.baseurl }}/faq/) before downloading the source code.
+The **change log** is at:
 
-The WebRTC issue tracker can be used for submitting bugs found in the native
-code package.
+  * <https://chromium.googlesource.com/external/webrtc/+log>
 
-<http://bugs.webrtc.org>
+Please read the [**License & Rights**]({{ site.baseurl }}/license/) and
+[**FAQ**]({{ site.baseurl }}/faq/) before downloading the source code.
+
+The WebRTC **issue tracker** can be used for submitting bugs found in the
+native code package.
+
+  * <https://bugs.webrtc.org>
 
 
 ##### Subpage Listing

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -9,41 +9,49 @@ crumb: iOS
 {% include toc-hide.html %}
 
 
-### Development environment
+### Development Environment
 
 An OS X machine is required for iOS development. While it's possible to
 develop purely from the command line with text editors, it's easiest to use
-XCode. Both methods will be illustrated here.
+Xcode. Both methods will be illustrated here.
 
 
-### Getting the code
+### Getting the Code
 
   1. Install [prerequisite software][1]
 
   2. Set the target OS in your environment:
 
      ~~~~~ bash
-     export GYP_DEFINES="OS=ios"
+     export GYP_CROSSCOMPILE=1
+     export GYP_DEFINES="OS=ios target_arch=arm"
+     export GYP_GENERATOR_FLAGS="output_dir=out_ios"
+     export GYP_GENERATORS=ninja
      ~~~~~
 
   3. Create a working directory, enter it, and run:
 
      ~~~~~ bash
-     fetch webrtc_ios
+     fetch --nohooks webrtc_ios
+     gclient sync
      ~~~~~
 
+     This will fetch a regular WebRTC checkout with the iOS-specific parts
+     added. The same checkout can be used for both Mac and iOS development,
+     depending on the OS you set in `GYP_DEFINES` (see above).
+
   4. You may want to disable Spotlight indexing for the checkout to speed up
-     file operations.
+     file operations..
 
 See [Development][2] for generic instructions on how
 to update the code in your checkout.
 
 
-### Compiling the code
+### Compiling the Code
 
 GYP is used to generate build instructions for ninja from the relevant .gyp files. Ninja is used to compile the source using the previously generated instructions. In order to configure GYP to generate build files for iOS certain environment variables need to be set. Those variables can be edited for the various build configurations as needed.
 
-Building for iOS device:
+Building for iOS Device:
 
 ~~~~~ bash
 export GYP_CROSSCOMPILE=1
@@ -57,16 +65,25 @@ Building for 64-bit iOS device:
 As above, except with:
 
 ~~~~~ bash
-export GYP_DEFINES="OS=ios target_arch=arm64 target_subarch=arm64"
+export GYP_DEFINES="OS=ios target_arch=arm64"
 export GYP_GENERATOR_FLAGS="output_dir=out_ios64"
 ~~~~~
 
-Building for simulator:
+Building for Simulator:
 
 As above, except with:
 
 ~~~~~ bash
 export GYP_DEFINES="OS=ios target_arch=ia32"
+export GYP_GENERATOR_FLAGS="output_dir=out_sim"
+~~~~~
+
+Building for 64-bit Simulator:
+
+As above, except with:
+
+~~~~~ bash
+export GYP_DEFINES="OS=ios target_arch=x64"
 export GYP_GENERATOR_FLAGS="output_dir=out_sim"
 ~~~~~
 
@@ -87,11 +104,12 @@ under `src/`. Now run the gyp generator script from the source root
 webrtc/build/gyp_webrtc
 ~~~~~
 
-Now to compile, just run ninja on the appropriate target. E.g.
+Now to compile, just run ninja on the appropriate target. For example:
 
 ~~~~~ bash
 ninja -C out_ios/Debug-iphoneos AppRTCDemo
 ninja -C out_ios/Release-iphoneos AppRTCDemo
+ninja -C out_sim/Debug-iphonesimulator AppRTCDemo
 ~~~~~
 
 For interesting targets to build, see the `.gyp` files in `webrtc/webrtc.gyp`,
@@ -101,12 +119,12 @@ For interesting targets to build, see the `.gyp` files in `webrtc/webrtc.gyp`,
 Some sample scripts are also available at [talk/app/webrtc/objc/README][3].
 
 
-### Compiling with XCode
+### Compiling with Xcode
 
-Compiling with XCode is not supported! What we do instead is compile using a
-script that runs ninja from XCode. In order to generate the relevant xcode
+Compiling with Xcode is not supported! What we do instead is compile using a
+script that runs ninja from Xcode. In order to generate the relevant Xcode
 project, add `xcode-ninja` to `GYP_GENERATORS` along with the targets you're
-interested in. By using XCode in this manner, we get the build speed of ninja
+interested in. By using Xcode in this manner, we get the build speed of ninja
 while at the same time getting access to the usual methods of
 deployment/debugging for iOS.
 
@@ -118,14 +136,14 @@ export GYP_GENERATORS="ninja,xcode-ninja"
 
 When running the generator script, you should see an `all.ninja.xcworkspace`
 file. You should be able to select the desired target and platform in the
-XCode usual fashion and build / deploy. Note that you will need to rerun the
+Xcode usual fashion and build/deploy. Note that you will need to rerun the
 GYP generator if you want to switch target platforms.
 
 
-### Deploying to device
+### Deploying to Device
 
-It's easiest to deploy to a device using XCode in `xcode-ninja` mode. Other
-command line tools exist as well, e.g. ios-deploy.
+It's easiest to deploy to a device using Xcode in `xcode-ninja` mode. Other
+command line tools exist as well, e.g. `ios-deploy`.
 
 
 [1]: {{ site.baseurl }}/native-code/development/prerequisite-sw/


### PR DESCRIPTION
Sync prerequisites page from old site. PRs 25 through 31 (this one) complete synchronization back through October 4, 2015. I believe this is the last of it.
