### PR TITLE
https://webrtc.org/native-code/native-apis/ - link to sample client application is broken

### DIFF
--- a/native-code/native-apis/index.md
+++ b/native-code/native-apis/index.md
@@ -24,7 +24,7 @@ applications.
 
 [1]: http://w3c.github.io/webrtc-pc/
 [2]: https://chromium.googlesource.com/external/webrtc/+/master/talk/app/webrtc
-[3]: https://chromium.googlesource.com/external/webrtc/+/master/talk/examples/peerconnection
+[3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/peerconnection
 
 
 


### PR DESCRIPTION
What steps will reproduce the problem?
1. open https://webrtc.org/native-code/native-apis/ in your favourite browser
2. click link "sample client application"

What is the expected result?
- Open link

What do you see instead?
- 404

https://bugs.chromium.org/p/webrtc/issues/detail?id=5439

Fix the link to "sample client application", which should be https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/peerconnection.
