### PR TITLE
Added tips on how to format code.

### DIFF
--- a/contributing/index.md
+++ b/contributing/index.md
@@ -67,13 +67,15 @@ back to you with the continuous build result.
 
 ### Code Style
 
-We generally follow the [Google][7] and [Chromium][8] C++ style guides. For
+We generally follow the [Chromium][8] style guides. For
 sake of consistency a reviewer might ask you to break the style guide, or
 extend your changes to make old non-compliant code up to date with the style
 guide.
 
-[7]: http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml
 [8]: http://www.chromium.org/developers/coding-style
+
+To format the code in a CL, you can use `git cl format`.
+To manually run the C++ lint checker, use `cpplint.py`.
 
 
 ### Contributor Agreement


### PR DESCRIPTION
Added tips about git cl format and cpplint.py.

Removed link to C++ style guide; it's better to have users click
through the Chromium style guide page instead. Partially since they're
not identical but also since there are more languages are also applicable:
Java, Python, HTML and JavaScript.
