### PR TITLE
gh-pages Jekyll 3 update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,4 +10,4 @@ highlighter: rouge
 permalink: /blog/:year/:month/:day/:title.html
 # relative_permalinks: true
 
-exclude: []
+exclude: [vendor]

--- a/_config.yml
+++ b/_config.yml
@@ -2,12 +2,7 @@
 title: WebRTC
 email: webmaster@webrtc.org
 description: "WebRTC is a free, open project that enables web browsers with Real-Time Communications (RTC) capabilities via simple JavaScript APIs. The WebRTC components have been optimized to best serve this purpose."
-#host: webrtc.getwebm.org
-#url: "http://webrtc.getwebm.org/"
 baseurl: "/webrtc-org"
-
-#twitter_username:
-#github_username:
 
 # Build settings
 markdown: kramdown
@@ -15,4 +10,4 @@ highlighter: rouge
 permalink: /blog/:year/:month/:day/:title.html
 # relative_permalinks: true
 
-exclude: [third-party,gulpfile.js,package.json,BUILD,_save,node_modules,vendor]
+exclude: []

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,6 +33,7 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/bootstrap.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/bootstrap-theme.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/webrtc.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/monokai.css">
     <script src="{{ site.baseurl }}/assets/js/jquery-1.11.1.js"></script>
     <script src="{{ site.baseurl }}/assets/js/bootstrap.js"></script>
     <script>

--- a/assets/css/monokai.css
+++ b/assets/css/monokai.css
@@ -1,60 +1,60 @@
-.highlight .hll { background-color: #49483e }
-.highlight  { background: #272822; color: #f8f8f2 }
-.highlight .c { color: #75715e } /* Comment */
-.highlight .err { color: #960050; background-color: #1e0010 } /* Error */
-.highlight .k { color: #66d9ef } /* Keyword */
-.highlight .l { color: #ae81ff } /* Literal */
-.highlight .n { color: #f8f8f2 } /* Name */
-.highlight .o { color: #f92672 } /* Operator */
-.highlight .p { color: #f8f8f2 } /* Punctuation */
-.highlight .cm { color: #75715e } /* Comment.Multiline */
-.highlight .cp { color: #75715e } /* Comment.Preproc */
-.highlight .c1 { color: #75715e } /* Comment.Single */
-.highlight .cs { color: #75715e } /* Comment.Special */
-.highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .kc { color: #66d9ef } /* Keyword.Constant */
-.highlight .kd { color: #66d9ef } /* Keyword.Declaration */
-.highlight .kn { color: #f92672 } /* Keyword.Namespace */
-.highlight .kp { color: #66d9ef } /* Keyword.Pseudo */
-.highlight .kr { color: #66d9ef } /* Keyword.Reserved */
-.highlight .kt { color: #66d9ef } /* Keyword.Type */
-.highlight .ld { color: #e6db74 } /* Literal.Date */
-.highlight .m { color: #ae81ff } /* Literal.Number */
-.highlight .s { color: #e6db74 } /* Literal.String */
-.highlight .na { color: #a6e22e } /* Name.Attribute */
-.highlight .nb { color: #f8f8f2 } /* Name.Builtin */
-.highlight .nc { color: #a6e22e } /* Name.Class */
-.highlight .no { color: #66d9ef } /* Name.Constant */
-.highlight .nd { color: #a6e22e } /* Name.Decorator */
-.highlight .ni { color: #f8f8f2 } /* Name.Entity */
-.highlight .ne { color: #a6e22e } /* Name.Exception */
-.highlight .nf { color: #a6e22e } /* Name.Function */
-.highlight .nl { color: #f8f8f2 } /* Name.Label */
-.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
-.highlight .nx { color: #a6e22e } /* Name.Other */
-.highlight .py { color: #f8f8f2 } /* Name.Property */
-.highlight .nt { color: #f92672 } /* Name.Tag */
-.highlight .nv { color: #f8f8f2 } /* Name.Variable */
-.highlight .ow { color: #f92672 } /* Operator.Word */
-.highlight .w { color: #f8f8f2 } /* Text.Whitespace */
-.highlight .mf { color: #ae81ff } /* Literal.Number.Float */
-.highlight .mh { color: #ae81ff } /* Literal.Number.Hex */
-.highlight .mi { color: #ae81ff } /* Literal.Number.Integer */
-.highlight .mo { color: #ae81ff } /* Literal.Number.Oct */
-.highlight .sb { color: #e6db74 } /* Literal.String.Backtick */
-.highlight .sc { color: #e6db74 } /* Literal.String.Char */
-.highlight .sd { color: #e6db74 } /* Literal.String.Doc */
-.highlight .s2 { color: #e6db74 } /* Literal.String.Double */
-.highlight .se { color: #ae81ff } /* Literal.String.Escape */
-.highlight .sh { color: #e6db74 } /* Literal.String.Heredoc */
-.highlight .si { color: #e6db74 } /* Literal.String.Interpol */
-.highlight .sx { color: #e6db74 } /* Literal.String.Other */
-.highlight .sr { color: #e6db74 } /* Literal.String.Regex */
-.highlight .s1 { color: #e6db74 } /* Literal.String.Single */
-.highlight .ss { color: #e6db74 } /* Literal.String.Symbol */
-.highlight .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #f8f8f2 } /* Name.Variable.Class */
-.highlight .vg { color: #f8f8f2 } /* Name.Variable.Global */
-.highlight .vi { color: #f8f8f2 } /* Name.Variable.Instance */
-.highlight .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+.highlighter-rouge .highlight .hll { background-color: #49483e }
+.highlighter-rouge .highlight  { background: #272822; color: #f8f8f2 }
+.highlighter-rouge .highlight .c { color: #75715e } /* Comment */
+.highlighter-rouge .highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+.highlighter-rouge .highlight .k { color: #66d9ef } /* Keyword */
+.highlighter-rouge .highlight .l { color: #ae81ff } /* Literal */
+.highlighter-rouge .highlight .n { color: #f8f8f2 } /* Name */
+.highlighter-rouge .highlight .o { color: #f92672 } /* Operator */
+.highlighter-rouge .highlight .p { color: #f8f8f2 } /* Punctuation */
+.highlighter-rouge .highlight .cm { color: #75715e } /* Comment.Multiline */
+.highlighter-rouge .highlight .cp { color: #75715e } /* Comment.Preproc */
+.highlighter-rouge .highlight .c1 { color: #75715e } /* Comment.Single */
+.highlighter-rouge .highlight .cs { color: #75715e } /* Comment.Special */
+.highlighter-rouge .highlight .ge { font-style: italic } /* Generic.Emph */
+.highlighter-rouge .highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlighter-rouge .highlight .kc { color: #66d9ef } /* Keyword.Constant */
+.highlighter-rouge .highlight .kd { color: #66d9ef } /* Keyword.Declaration */
+.highlighter-rouge .highlight .kn { color: #f92672 } /* Keyword.Namespace */
+.highlighter-rouge .highlight .kp { color: #66d9ef } /* Keyword.Pseudo */
+.highlighter-rouge .highlight .kr { color: #66d9ef } /* Keyword.Reserved */
+.highlighter-rouge .highlight .kt { color: #66d9ef } /* Keyword.Type */
+.highlighter-rouge .highlight .ld { color: #e6db74 } /* Literal.Date */
+.highlighter-rouge .highlight .m { color: #ae81ff } /* Literal.Number */
+.highlighter-rouge .highlight .s { color: #e6db74 } /* Literal.String */
+.highlighter-rouge .highlight .na { color: #a6e22e } /* Name.Attribute */
+.highlighter-rouge .highlight .nb { color: #f8f8f2 } /* Name.Builtin */
+.highlighter-rouge .highlight .nc { color: #a6e22e } /* Name.Class */
+.highlighter-rouge .highlight .no { color: #66d9ef } /* Name.Constant */
+.highlighter-rouge .highlight .nd { color: #a6e22e } /* Name.Decorator */
+.highlighter-rouge .highlight .ni { color: #f8f8f2 } /* Name.Entity */
+.highlighter-rouge .highlight .ne { color: #a6e22e } /* Name.Exception */
+.highlighter-rouge .highlight .nf { color: #a6e22e } /* Name.Function */
+.highlighter-rouge .highlight .nl { color: #f8f8f2 } /* Name.Label */
+.highlighter-rouge .highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlighter-rouge .highlight .nx { color: #a6e22e } /* Name.Other */
+.highlighter-rouge .highlight .py { color: #f8f8f2 } /* Name.Property */
+.highlighter-rouge .highlight .nt { color: #f92672 } /* Name.Tag */
+.highlighter-rouge .highlight .nv { color: #f8f8f2 } /* Name.Variable */
+.highlighter-rouge .highlight .ow { color: #f92672 } /* Operator.Word */
+.highlighter-rouge .highlight .w { color: #f8f8f2 } /* Text.Whitespace */
+.highlighter-rouge .highlight .mf { color: #ae81ff } /* Literal.Number.Float */
+.highlighter-rouge .highlight .mh { color: #ae81ff } /* Literal.Number.Hex */
+.highlighter-rouge .highlight .mi { color: #ae81ff } /* Literal.Number.Integer */
+.highlighter-rouge .highlight .mo { color: #ae81ff } /* Literal.Number.Oct */
+.highlighter-rouge .highlight .sb { color: #e6db74 } /* Literal.String.Backtick */
+.highlighter-rouge .highlight .sc { color: #e6db74 } /* Literal.String.Char */
+.highlighter-rouge .highlight .sd { color: #e6db74 } /* Literal.String.Doc */
+.highlighter-rouge .highlight .s2 { color: #e6db74 } /* Literal.String.Double */
+.highlighter-rouge .highlight .se { color: #ae81ff } /* Literal.String.Escape */
+.highlighter-rouge .highlight .sh { color: #e6db74 } /* Literal.String.Heredoc */
+.highlighter-rouge .highlight .si { color: #e6db74 } /* Literal.String.Interpol */
+.highlighter-rouge .highlight .sx { color: #e6db74 } /* Literal.String.Other */
+.highlighter-rouge .highlight .sr { color: #e6db74 } /* Literal.String.Regex */
+.highlighter-rouge .highlight .s1 { color: #e6db74 } /* Literal.String.Single */
+.highlighter-rouge .highlight .ss { color: #e6db74 } /* Literal.String.Symbol */
+.highlighter-rouge .highlight .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.highlighter-rouge .highlight .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.highlighter-rouge .highlight .vg { color: #f8f8f2 } /* Name.Variable.Global */
+.highlighter-rouge .highlight .vi { color: #f8f8f2 } /* Name.Variable.Instance */
+.highlighter-rouge .highlight .il { color: #ae81ff } /* Literal.Number.Integer.Long */

--- a/assets/css/webrtc.scss
+++ b/assets/css/webrtc.scss
@@ -121,23 +121,13 @@ article.page-content {
     font-size: $fsize * 1.1;
     font-weight: bold;
   }
-  code {
-    // Inline code overrides
-    padding: 2px 4px;
-    font-size: 90%;
-    color: #006B24;
-    background-color: #f9f2f4;
-    border-radius: 4px;
-  }
   code, kbd, pre, samp {
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   }
   // Need a special selector for the case of <code> within <pre>,
-  // to prevent excess padding-left. Must also correct <code>'s
-  // background-color to match <pre>'s.
+  // to prevent excess padding-left.
   pre code {
     padding-left: 0;
-    background-color: #f5f5f5;
   }
   p {
     a, code, pre {
@@ -320,11 +310,11 @@ pre {
 // Code spans
 // Explicit Bootstrap overrides
 code {
-  //padding: 2px 4px;
-  //font-size: 90%;
-  //color: #c7254e;
-  //background-color: #f9f2f4;
-  //border-radius: 4px;
+  padding: 2px 4px;
+  font-size: 95%;
+  color: #000;
+  background-color: #eee;
+  border-radius: 4px;
 }
 
 // Debug container
@@ -357,265 +347,4 @@ div#debug {
     border: none;
   }
   // End Google CSE overrides
-}
-
-// Codeblock syntax highlighting (pygments)
-
-div.code {
-  // gh-pages syntax highlighting is a mess.
-  // Kludge to suppress code block line nos.,
-  // since there's seems to be no config option.
-  span.line-numbers {
-    display: none;
-  }
-  // Specific `pre` rules are needed to trump Bootstrap defaults
-  // This is a bit ugly, but works.
-  pre {
-    color: #f8f8f2;
-    background-color: #272822;
-    border: none;
-    //border-top-left-radius: 0;
-    //border-top-right-radius: 0;
-    //border-bottom-right-radius: 0;
-    //border-bottom-left-radius: 0;
-    // And ... Pygments "Monokai" styles
-    background: #272822;
-    color: #f8f8f2;
-    .hll {
-      background-color: #49483e;
-    }
-    .c {
-      color: #75715e;
-    }
-    /* Comment */
-    .err {
-      color: #960050;
-      background-color: #1e0010;
-    }
-    /* Error */
-    .k {
-      color: #66d9ef;
-    }
-    /* Keyword */
-    .l {
-      color: #ae81ff;
-    }
-    /* Literal */
-    .n {
-      color: #f8f8f2;
-    }
-    /* Name */
-    .o {
-      color: #f92672;
-    }
-    /* Operator */
-    .p {
-      color: #f8f8f2;
-    }
-    /* Punctuation */
-    .cm {
-      color: #75715e;
-    }
-    /* Comment.Multiline */
-    .cp {
-      color: #75715e;
-    }
-    /* Comment.Preproc */
-    .c1 {
-      color: #75715e;
-    }
-    /* Comment.Single */
-    .cs {
-      color: #75715e;
-    }
-    /* Comment.Special */
-    .ge {
-      font-style: italic;
-    }
-    /* Generic.Emph */
-    .gs {
-      font-weight: bold;
-    }
-    /* Generic.Strong */
-    .kc {
-      color: #66d9ef;
-    }
-    /* Keyword.Constant */
-    .kd {
-      color: #66d9ef;
-    }
-    /* Keyword.Declaration */
-    .kn {
-      color: #f92672;
-    }
-    /* Keyword.Namespace */
-    .kp {
-      color: #66d9ef;
-    }
-    /* Keyword.Pseudo */
-    .kr {
-      color: #66d9ef;
-    }
-    /* Keyword.Reserved */
-    .kt {
-      color: #66d9ef;
-    }
-    /* Keyword.Type */
-    .ld {
-      color: #e6db74;
-    }
-    /* Literal.Date */
-    .m {
-      color: #ae81ff;
-    }
-    /* Literal.Number */
-    .s {
-      color: #e6db74;
-    }
-    /* Literal.String */
-    .na {
-      color: #a6e22e;
-    }
-    /* Name.Attribute */
-    .nb {
-      color: #f8f8f2;
-    }
-    /* Name.Builtin */
-    .nc {
-      color: #a6e22e;
-    }
-    /* Name.Class */
-    .no {
-      color: #66d9ef;
-    }
-    /* Name.Constant */
-    .nd {
-      color: #a6e22e;
-    }
-    /* Name.Decorator */
-    .ni {
-      color: #f8f8f2;
-    }
-    /* Name.Entity */
-    .ne {
-      color: #a6e22e;
-    }
-    /* Name.Exception */
-    .nf {
-      color: #a6e22e;
-    }
-    /* Name.Function */
-    .nl {
-      color: #f8f8f2;
-    }
-    /* Name.Label */
-    .nn {
-      color: #f8f8f2;
-    }
-    /* Name.Namespace */
-    .nx {
-      color: #a6e22e;
-    }
-    /* Name.Other */
-    .py {
-      color: #f8f8f2;
-    }
-    /* Name.Property */
-    .nt {
-      color: #f92672;
-    }
-    /* Name.Tag */
-    .nv {
-      color: #f8f8f2;
-    }
-    /* Name.Variable */
-    .ow {
-      color: #f92672;
-    }
-    /* Operator.Word */
-    .w {
-      color: #f8f8f2;
-    }
-    /* Text.Whitespace */
-    .mf {
-      color: #ae81ff;
-    }
-    /* Literal.Number.Float */
-    .mh {
-      color: #ae81ff;
-    }
-    /* Literal.Number.Hex */
-    .mi {
-      color: #ae81ff;
-    }
-    /* Literal.Number.Integer */
-    .mo {
-      color: #ae81ff;
-    }
-    /* Literal.Number.Oct */
-    .sb {
-      color: #e6db74;
-    }
-    /* Literal.String.Backtick */
-    .sc {
-      color: #e6db74;
-    }
-    /* Literal.String.Char */
-    .sd {
-      color: #e6db74;
-    }
-    /* Literal.String.Doc */
-    .s2 {
-      color: #e6db74;
-    }
-    /* Literal.String.Double */
-    .se {
-      color: #ae81ff;
-    }
-    /* Literal.String.Escape */
-    .sh {
-      color: #e6db74;
-    }
-    /* Literal.String.Heredoc */
-    .si {
-      color: #e6db74;
-    }
-    /* Literal.String.Interpol */
-    .sx {
-      color: #e6db74;
-    }
-    /* Literal.String.Other */
-    .sr {
-      color: #e6db74;
-    }
-    /* Literal.String.Regex */
-    .s1 {
-      color: #e6db74;
-    }
-    /* Literal.String.Single */
-    .ss {
-      color: #e6db74;
-    }
-    /* Literal.String.Symbol */
-    .bp {
-      color: #f8f8f2;
-    }
-    /* Name.Builtin.Pseudo */
-    .vc {
-      color: #f8f8f2;
-    }
-    /* Name.Variable.Class */
-    .vg {
-      color: #f8f8f2;
-    }
-    /* Name.Variable.Global */
-    .vi {
-      color: #f8f8f2;
-    }
-    /* Name.Variable.Instance */
-    .il {
-      color: #ae81ff;
-    }
-    /* Literal.Number.Integer.Long */
-  }
 }


### PR DESCRIPTION
See https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
- Rouge and kramdown now mandatory on gh-pages
  (good), so fix code and code block styling
  (webrtc.scss, monokai.css, default template).
- Misc: de-cruft _config.yml

modified:   _layouts/default.html
modified:   assets/css/monokai.css
modified:   assets/css/webrtc.scss
modified:   _config.yml
