### PR TITLE
Remove instructions with JAVA_HOME

### DIFF
--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -14,20 +14,13 @@ Android development is only supported on Linux.
 
   1. Install [prerequisite software][1]
 
-  2. Set the path to your Java OpenJDK 7 dir if you're not using the Ubuntu
-     default:
-
-     ~~~~~ bash
-     export JAVA_HOME=<location of OpenJDK 7>
-     ~~~~~
-
-  3. Set the target OS in your environment:
+  2. Set the target OS in your environment:
 
      ~~~~~ bash
      export GYP_DEFINES="OS=android"
      ~~~~~
 
-  4. Create a working directory, enter it, and run:
+  3. Create a working directory, enter it, and run:
 
      ~~~~~ bash
      fetch --nohooks webrtc_android

--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -22,16 +22,9 @@ First, be sure to install the [prerequisite software][3].
 
 For desktop development:
 
-  1. If you're on Linux and have OpenJDK 7 installed in another location than
-     Ubuntu's default:
+  1. On Windows, launch a command prompt as Administrator.
 
-     ~~~~~ bash
-     export JAVA_HOME=<location of OpenJDK 7>
-     ~~~~~
-
-  2. On Windows, launch a command prompt as Administrator.
-
-  3. Create a working directory, enter it, and run `fetch webrtc`:
+  2. Create a working directory, enter it, and run `fetch webrtc`:
 
      ~~~~~ bash
      mkdir webrtc-checkout
@@ -46,14 +39,14 @@ For desktop development:
      `gclient sync` may be enough, but you might also need to start over
      cleanly).
 
-  4. Optionally you can specify how new branches should be tracked:
+  3. Optionally you can specify how new branches should be tracked:
 
      ~~~~~ bash
      git config branch.autosetupmerge always
      git config branch.autosetuprebase always
      ~~~~~
 
-  5. Alternatively, you can create new local branches like this (recommended):
+  4. Alternatively, you can create new local branches like this (recommended):
 
      ~~~~~ bash
      cd src


### PR DESCRIPTION
The JAVA_HOME environment variable is no longer needed to build on Android
or Linux, so let's remove it from the instructions.
