### PR TITLE
Remove references to install-build-deps.sh

### DIFF
--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -33,10 +33,13 @@ For desktop development:
      gclient sync
      ~~~~~
 
-     This will **take a long time** because it downloads the whole Chromium
-     repository and dependencies, which are several gigabytes. **Do not**
-     interrupt this step or you may need to start all over agan (a new
-     `gclient sync` may be enough, but you might also need to start over
+     NOTICE: Due to [bug 5578][12] you may have to press 'y' to accept a license
+     dialog for downloading Google Play Services SDK.
+
+     The dowload will **take a long time** because it downloads the whole
+     Chromium repository and dependencies, which are several gigabytes.
+     **Do not** interrupt this step or you may need to start all over agan (a
+     new `gclient sync` may be enough, but you might also need to start over
      cleanly).
 
   3. Optionally you can specify how new branches should be tracked:
@@ -360,5 +363,6 @@ Target name `turnserver`. In active development to reach compatibility with
 [9]: {{ site.baseurl }}/contributing/
 [10]: http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
 [11]: {{ site.baseurl }}/native-code/native-apis/
+[12]: https://bugs.chromium.org/p/webrtc/issues/detail?id=5578
 [RFC 5389]: https://tools.ietf.org/html/rfc5389
 [RFC 5766]: https://tools.ietf.org/html/rfc5766

--- a/native-code/development/prerequisite-sw/index.md
+++ b/native-code/development/prerequisite-sw/index.md
@@ -26,46 +26,6 @@ This, and more, is described on the Chromium site:
 
 <https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md>
 
-A script is provided for Ubuntu, which is available after your first gclient
-sync:
-
-~~~~~ bash
-./build/install-build-deps.sh
-~~~~~
-
-PulseAudio is missing from the script. On Ubuntu, this is provided by the
-`libpulse-dev` package.
-
-Although the [install-build-deps.sh][1] script is the recommended method, it
-will install much more than you need. Here is a (hopefully complete) minimal
-list of packages to install (`sudo apt-get install ...`):
-
-~~~~~ bash
-g++ (>= 4.2)
-python (>= 2.4)
-libnss3-dev >= 3.12
-libasound2-dev
-libpulse-dev
-libjpeg62-dev
-libxv-dev
-libgtk2.0-dev
-libexpat1-dev
-~~~~~
-
-[1]: https://code.google.com/p/chromium/codesearch#chromium/src/build/install-build-deps.sh
-
-To create 32-bit builds for Linux on a 64-bit system (not needed or Android
-builds):
-
-~~~~~ bash
-lib32asound2-dev
-lib32z1
-lib32ncurses5
-lib32bz2-1.0
-~~~~~
-
-Tips for other distributions are available on the Chromium page.
-
 
 ### Windows
 


### PR DESCRIPTION
Now that we're using sysroot images from Chromium, no libraries
needs to be installed on the system in order to build on Linux.

I also verified that the libpulse-dev package is part of that image.
