### PR TITLE
Readd some of the install-build-deps.sh instructions

### DIFF
--- a/native-code/development/prerequisite-sw/index.md
+++ b/native-code/development/prerequisite-sw/index.md
@@ -21,8 +21,21 @@ crumb: Prerequisites
 
 ### Linux (Ubuntu/Debian)
 
-No specific prerequisites, but you may want to have a look at the
-[Chromium Linux Build instructions][2] if you experience problems building.
+A script is provided for Ubuntu, which is unfortunately only available after
+your first gclient sync:
+
+~~~~~ bash
+./build/install-build-deps.sh
+~~~~~
+
+Most of the libraries installed with this script are not needed since we now
+build using Debian sysroot images in build/linux, but there are still some tools
+needed for the build that are installed with [install-build-deps.sh][1]
+
+[1]: https://code.google.com/p/chromium/codesearch#chromium/src/build/install-build-deps.sh
+
+You may also want to have a look at the [Chromium Linux Build instructions][2]
+if you experience any other problems building.
 
 
 ### Windows


### PR DESCRIPTION
Even if we use sysroot images for all libraries, there
are still tools needed to build that are installed by the
install-build-deps.sh script.

Example of bug this solves: https://bugs.chromium.org/p/webrtc/issues/detail?id=5745
