### PR TITLE
Bump required Xcode to 5 to align with Chromium.

### DIFF
--- a/native-code/development/prerequisite-sw/index.md
+++ b/native-code/development/prerequisite-sw/index.md
@@ -32,7 +32,7 @@ Follow step 1 and 2 at [Chromium's build instructions for Windows][3].
 
 ### OS X
 
-Xcode 3.0 or higher. Latest Xcode is recommended to be able to build all code.
+Xcode 5 or higher. Latest Xcode is recommended to be able to build all code.
 
 
 ### Android


### PR DESCRIPTION
https://www.chromium.org/dev/developers/how-tos/get-the-code
mentions that Xcode 5 or later is needed, we should require the same.
