### PR TITLE
Adding link to getting started information

### DIFF
--- a/contributing/index.md
+++ b/contributing/index.md
@@ -26,7 +26,7 @@ when you have found a bug and have implemented a fix for it.
 
 ### How to Create a Patch
 
-These instructions assume you already have followed the getting started guide and can build the WebRTC code. The work flow is:
+These instructions assume you already have followed the [getting started guide]({{ site.baseurl }}/native-code/development/) and can build the WebRTC code. The work flow is:
 
   1. Make sure you accept and fill out the contributor agreement
 


### PR DESCRIPTION
The 'contributing' page at webrtc.org mentions the getting started guide
but doesn't link to it, which makes getting started difficult. This
change adds a link from https://webrtc.org/contributing to
http://webrtc.org/native-code/development/ to make this easier.
