### PR TITLE
Add a Logging page that describes obtaining logs on different platforms.

### DIFF
--- a/bugs/index.md
+++ b/bugs/index.md
@@ -63,6 +63,9 @@ Please include as many relevant details as possible.
     * If you experience a crash while using WebRTC native code, please include
       the full stacktrace.
 
+  * For **functional** issues or **ICE** issues, in either Chrome or a native
+    application, please gather a [native log][5].
+
   * For **connectivity** issues on Chrome, while the call is in progress,
 
     * please open **chrome://webrtc-internals** in another tab,
@@ -105,3 +108,4 @@ Please include as many relevant details as possible.
 [2]: http://www.chromium.org/for-testers/bug-reporting-guidelines/reporting-crash-bug
 [3]: https://code.google.com/p/chromium/issues/entry?template=Audio/Video%20Issue
 [4]: https://bugs.chromium.org/p/webrtc/issues/entry
+[5]: {{ site.baseurl }}/native-code/logging/

--- a/native-code/index.md
+++ b/native-code/index.md
@@ -34,3 +34,4 @@ native code package.
     * [Prerequisite software]({{ site.baseurl }}/native-code/development/prerequisite-sw/)
   * [iOS]({{ site.baseurl }}/native-code/ios/)
   * [Native APIs]({{ site.baseurl }}/native-code/native-apis/)
+  * [Logging]({{ site.baseurl }}/native-code/logging/)

--- a/native-code/logging/index.md
+++ b/native-code/logging/index.md
@@ -1,0 +1,66 @@
+---
+layout: default
+title: Logging
+permalink: /native-code/logging/
+---
+
+{% include toc-hide.html %}
+
+Native logs are often valuable in order to debug issues that can't be easily
+reproduced. Following are instructions for gathering logs on various platforms.
+
+### Chrome
+
+Running Chrome with the following command line flags will turn on `INFO` and
+`VERBOSE` logging for WebRTC:
+
+~~~~ bash
+chrome --enable-logging --vmodule=*/webrtc/*=1
+~~~~
+
+More details on Chrome logging can be found [here][1].
+
+The log will be named 'chrome_debug.log' and saved in the Chrome
+[user data directory][2].
+
+### Native applications
+
+To enable native logs for a native application, you can either:
+
+  * Use a debug build of WebRTC (a build where `NDEBUG` is not defined),
+    which will enable `INFO` logging by default.
+
+  * Call `rtc::LogMessage::LogToDebug(rtc::LS_INFO)` within your application.
+    Or use `LS_VERBOSE` to enable `VERBOSE` logging.
+
+For the location of the log output on different platforms, see below.
+
+#### Android
+
+Logged to Android system log. Can be obtained using:
+
+~~~~ bash
+adb logcat -s "libjingle"
+~~~~
+
+#### iOS
+
+Only logged to `stderr` by default. To log to a file, use `RTCFileLogger`.
+
+#### Mac
+
+For debug builds of WebRTC (builds where `NDEBUG` is not defined), logs to
+`stderr`. To do this for release builds as well, set a boolean preference named
+'logToStderr' to `true` for your application. Or, use `RTCFileLogger` to log to
+a file.
+
+#### Windows
+
+Logs to the debugger and `stderr`.
+
+#### Linux/Other Platforms
+
+Logs to `stderr`.
+
+[1]: {{ site.baseurl }}/web-apis/chrome/
+[2]: http://dev.chromium.org/user-experience/user-data-directory


### PR DESCRIPTION
Also recommending that a native log is included in bug reports that deal with functional issues or ICE issues.

This will help a lot when someone brings up an issue on discuss-webrtc, and I want to tell them how to get a log.
