### PR TITLE
Update instructions for iOS

### DIFF
--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -15,25 +15,32 @@ A macOS machine is required for iOS development. While it's possible to
 develop purely from the command line with text editors, it's easiest to use
 Xcode. Both methods will be illustrated here.
 
+You will need to install [Chromium depot_tools][1].
 
 ### Getting the Code
 
-  1. Install [prerequisite software][1]
+Create a working directory, enter it, and run:
 
-  2. Create a working directory, enter it, and run:
+~~~~~ bash
+fetch --nohooks webrtc_ios
+gclient sync
+~~~~~
 
-     ~~~~~ bash
-     fetch --nohooks webrtc_ios
-     gclient sync
-     ~~~~~
+This will fetch a regular WebRTC checkout with the iOS-specific parts
+added. The same checkout can be used for both Mac and iOS development,
+since you can generate your [Ninja][4] project files in multiple
+directories (see below).
 
-     This will fetch a regular WebRTC checkout with the iOS-specific parts
-     added. The same checkout can be used for both Mac and iOS development,
-     since you can generate your [Ninja][4] project files in multiple
-     directories (see below).
+Note that the git repository root is in `src`.
 
-  3. You may want to disable Spotlight indexing for the checkout to speed up
-     file operations..
+You may want to disable Spotlight indexing for the checkout to speed up
+file operations.
+
+From here you can check out a new local branch with:
+
+~~~~~ bash
+git new-branch <branch name>
+~~~~~
 
 See [Development][2] for generic instructions on how
 to update the code in your checkout.
@@ -45,55 +52,34 @@ to update the code in your checkout.
 [GN][5] to generate build files for iOS certain variables need to be set.
 Those variables can be edited for the various build configurations as needed.
 
+The variables you should care about are the following:
+
+* `target_os`:
+  - To build for iOS this should be set as `target_os="ios"` in your `gn args`.
+  The default is whatever OS you are building on.
+* `target_cpu`:
+  - For builds targeting iOS devices, this should be set to either `"arm"` or
+  `"arm64"`, depending on the architecture of the device. For builds to run in
+  the simulator, this should be set to `"x64"`.
+* `is_component_build`:
+  - Component builds don't take as long to link, but have runtime performance
+  implications. They are not supported on iOS, so this should always be set
+  to `false`.
+* `is_debug`:
+  - Debug builds are the default. When building for release, specify `false`.
+
 The component build is the default for Debug builds, which are also enabled by
-default unless `is_debug=false` is specified. iOS needs static builds, which is
-why `is_component_build=false` is specified for all the examples above.
+default unless `is_debug=false` is specified.
 
+The [GN][5] command for generating build files is `gn gen <output folder>`.
 
-#### Targeting iOS Devices
-
-The different output directories can be replaced with any directory of your own
-choice. When running GN; make sure your current working directory is src/ of
-your workspace, then run:
-
+#### Examples
 ~~~~~ bash
-gn gen out/Debug-device-arm32 --args='target_os="ios" target_cpu="arm" is_component_build=false'
-~~~~~
+# debug build for 64-bit iOS
+gn gen out/ios_64 --args='target_os="ios" target_cpu="arm64" is_component_build=false'
 
-#### Targeting 64-bit iOS devices
-
-~~~~~ bash
-gn gen out/Debug-device-arm64 --args='target_os="ios" target_cpu="arm64" is_component_build=false'
-~~~~~
-
-**NOTICE:** To build for devices, you must have a signing identity configured
-for your Xcode installation. You can check this by running:
-
-~~~~~ bash
-python build/config/ios/find_signing_identity.py
-~~~~~
-
-If you need to build for ARM devices without this setup, you can add the
-`ios_enable_code_signing=false` variable to GN's arguments.
-
-#### Targeting the iOS Simulator
-
-~~~~~ bash
-gn gen out/Debug-sim32 --args='target_os="ios" target_cpu="x86" is_component_build=false'
-~~~~~
-
-#### Targeting 64-bit iOS Simulator
-
-~~~~~ bash
-gn gen out/Debug-sim64 --args='target_os="ios" target_cpu="x64" is_component_build=false'
-~~~~~
-
-#### Targeting macOS
-
-The host OS is the default `target_os`, so you don't need to specify it:
-
-~~~~~ bash
-gn gen out/Debug-mac
+# debug build for simulator
+gn gen out/ios_sim --args='target_os="ios" target_cpu="x64" is_component_build=false'
 ~~~~~
 
 ### Compiling with ninja
@@ -101,13 +87,19 @@ gn gen out/Debug-mac
 To compile, just run ninja on the appropriate target. For example:
 
 ~~~~~ bash
-ninja -C out/Debug-device-arm32 AppRTCMobile
+ninja -C out/ios_64 AppRTCMobile
 ~~~~~
 
-Some sample scripts are also available in [webrtc/build/ios][3].
+Replace `AppRTCMobile` in the command above with the target you
+are interested in.
 
+To see a list of available targets, run `gn ls out/<output folder>`.
 
-### Compiling with Xcode
+### Using Xcode
+
+GN can generate an Xcode project from the build files. The build targets
+in the generated project will invoke a script that builds with ninja instead
+of building the project directly.
 
 Compiling with Xcode is not supported! What we do instead is compile using a
 script that runs ninja from Xcode. In order to generate the relevant Xcode
@@ -120,15 +112,52 @@ Using this, you can select the desired target and platform in the Xcode usual
 fashion and build/deploy. Note that you will need to rerun GN if you want to
 switch target platforms.
 
+### Running the tests
+
+There are several test targets in WebRTC. To run them, simply invoke them from
+the command line, for example:
+
+~~~~~ bash
+./out/mac/peerconnection_unittests
+~~~~~
+
+To run a specific test or collection of tests, pass the `--gtest_filter` argument
+to the test binary, for example:
+
+~~~~~ bash
+./out/mac/peerconnection_unittests --gest_filter="WebRtcSessionTest.*"
+~~~~~
+
+This will run all tests under `WebRtcSessionTest`.
+
+To run tests on device, or in the simulator, the `.app` bundle must be deployed
+to the device and run from there. See the next section.
 
 ### Deploying to Device
 
 It's easiest to deploy to a device using Xcode. Other command line tools exist
 as well, e.g. `ios-deploy`.
 
+### Using WebRTC in your app
+
+To build WebRTC for use in a native iOS app, it's easiest to build
+`WebRTC.framework`. This can be done with ninja as follows, replacing `ios`
+with the actual location of your generated build files.
+
+~~~~~ bash
+ninja -C out/ios rtc_sdk_framework_objc
+~~~~~
+
+This should result in a `.framework` bundle being generated in `out/ios`.
+This bundle can now be directly included in another app.
+
+If you need a FAT `.framework`, that is, a binary that contains code for
+multiple architectures, and will work both on device and in the simulator,
+a script is available [here][3]
+
 
 [1]: {{ site.baseurl }}/native-code/development/prerequisite-sw/
 [2]: {{ site.baseurl }}/native-code/development/
-[3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/build/ios
+[3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/build/ios/build_ios_libs.sh
 [4]: https://chromium.googlesource.com/chromium/src/+/master/docs/ninja_build.md
 [5]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/README.md

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -15,7 +15,7 @@ A macOS machine is required for iOS development. While it's possible to
 develop purely from the command line with text editors, it's easiest to use
 Xcode. Both methods will be illustrated here.
 
-You will need to install [Chromium depot_tools][1].
+_NOTICE:_ You will need to install [Chromium depot_tools][1].
 
 ### Getting the Code
 
@@ -31,10 +31,10 @@ added. The same checkout can be used for both Mac and iOS development,
 since you can generate your [Ninja][4] project files in multiple
 directories (see below).
 
-Note that the git repository root is in `src`.
-
 You may want to disable Spotlight indexing for the checkout to speed up
 file operations.
+
+Note that the git repository root is in `src`.
 
 From here you can check out a new local branch with:
 
@@ -56,7 +56,8 @@ The variables you should care about are the following:
 
 * `target_os`:
   - To build for iOS this should be set as `target_os="ios"` in your `gn args`.
-  The default is whatever OS you are building on.
+  The default is whatever OS you are running the script on, so this can be
+  omitted when generating build files for macOS.
 * `target_cpu`:
   - For builds targeting iOS devices, this should be set to either `"arm"` or
   `"arm64"`, depending on the architecture of the device. For builds to run in
@@ -73,7 +74,15 @@ default unless `is_debug=false` is specified.
 
 The [GN][5] command for generating build files is `gn gen <output folder>`.
 
+After you've generated your build files once, subsequent invocations of `gen gen`
+with the same output folder will use the same arguments as first supplied.
+To edit these at any time use `gn args <output folder>`. This will open up
+a file in `$EDITOR` where you can edit the arguments. When you've made
+changes and save the file, `gn` will regenerate your project files for you
+with the new arguments.
+
 #### Examples
+
 ~~~~~ bash
 # debug build for 64-bit iOS
 gn gen out/ios_64 --args='target_os="ios" target_cpu="arm64" is_component_build=false'
@@ -97,46 +106,48 @@ To see a list of available targets, run `gn ls out/<output folder>`.
 
 ### Using Xcode
 
-GN can generate an Xcode project from the build files. The build targets
-in the generated project will invoke a script that builds with ninja instead
-of building the project directly.
+Xcode is the default and preferred IDE to develop for the iOS platform.
+
+*Generating an Xcode project*
+
+To have GN generate Xcode project files, pass the argument `--ide=xcode`
+when running `gn gen`. This will result in a file named `all.xcworkspace`
+placed in your specified output directory.
+
+Example:
+~~~~~ bash
+gn gen out/ios --args='target_os="ios" target_cpu="arm64" is_component_build=false' --ide=xcode
+open -a Xcode.app out/ios/all.xcworkspace
+~~~~~
+
+*Compile and run with Xcode*
 
 Compiling with Xcode is not supported! What we do instead is compile using a
-script that runs ninja from Xcode. In order to generate the relevant Xcode
-project, add `--ide=xcode` to the GN command. By using Xcode in this manner, we
-get the build speed of ninja while at the same time getting access to the usual
-methods of deployment/debugging for iOS.
+script that runs ninja from Xcode. This is done with a custom _run script_
+action in the build phases of the generated project. This script will simply
+call ninja as you would when building from the command line.
 
-After running GN, you'll find a `all.xcworkspace` file in the output directory.
-Using this, you can select the desired target and platform in the Xcode usual
-fashion and build/deploy. Note that you will need to rerun GN if you want to
-switch target platforms.
+This gives us access to the usual deployment/debugging workflow iOS developers
+are used to in Xcode, without sacrificing the build speed of Ninja.
 
 ### Running the tests
 
-There are several test targets in WebRTC. To run them, simply invoke them from
-the command line, for example:
+There are several test targets in WebRTC. To run the tests, you must deploy the
+`.app` bundle to a device (see next section) and run them from there.
+To run a specific test or collection of tests, normally with gtest one would pass
+the `--gtest_filter` argument to the test binary when running. To do this when
+running the tests from Xcode, from the targets menu, select the test bundle
+and press _edit scheme..._ at the bottom of the target dropdown menu. From there
+click _Run_ in the sidebar and add `--gtest_filter` to the _Arguments passed on
+Launch_ list.
 
-~~~~~ bash
-./out/mac/peerconnection_unittests
-~~~~~
-
-To run a specific test or collection of tests, pass the `--gtest_filter` argument
-to the test binary, for example:
-
-~~~~~ bash
-./out/mac/peerconnection_unittests --gest_filter="WebRtcSessionTest.*"
-~~~~~
-
-This will run all tests under `WebRtcSessionTest`.
-
-To run tests on device, or in the simulator, the `.app` bundle must be deployed
-to the device and run from there. See the next section.
+If deploying to a device via the command line using [`ios-deploy`][6],
+use the `-a` flag to pass arguments to the executable on launch.
 
 ### Deploying to Device
 
 It's easiest to deploy to a device using Xcode. Other command line tools exist
-as well, e.g. `ios-deploy`.
+as well, e.g. [`ios-deploy`][6].
 
 ### Using WebRTC in your app
 
@@ -161,3 +172,4 @@ a script is available [here][3]
 [3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/build/ios/build_ios_libs.sh
 [4]: https://chromium.googlesource.com/chromium/src/+/master/docs/ninja_build.md
 [5]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/README.md
+[6]: https://github.com/phonegap/ios-deploy

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -149,6 +149,18 @@ use the `-a` flag to pass arguments to the executable on launch.
 It's easiest to deploy to a device using Xcode. Other command line tools exist
 as well, e.g. [`ios-deploy`][6].
 
+**NOTICE:** To deploy to an iOS device you must have a valid signing identity
+set up. You can verify this by running:
+
+~~~~ bash
+xcrun security find-identity -v -p codesigning
+~~~~
+
+If you don't have a valid signing identity, you can still build for ARM,
+but you won't be able to deploy your code to an iOS device. To do this,
+add the flag `ios_enable_code_signing=false` to the `gn gen` args when you
+generate the build files.
+
 ### Using WebRTC in your app
 
 To build WebRTC for use in a native iOS app, it's easiest to build


### PR DESCRIPTION
This PR contains an update to the getting started instructions for iOS. 

Additions:
+ Section on running tests
+ Section on building iOS libs

Changes:
+  Explain GN arguments 1 by 1 rather than providing examples of all combinations
+  Little clarification in "getting the code" section