### PR TITLE
Updating "Component Builds" documentation

### DIFF
--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -49,16 +49,6 @@ the code, building etc.
       * To build for 32-bit x86: use `target_cpu="x86"`
       * To build for 64-bit x64: use `target_cpu="x64"`
 
-     **NOTICE: Component Builds are not supported**
-
-     The Gn argument `is_component_build` is currently ignored for WebRTC builds.
-     [Component builds][5] are supported by Chromium and the argument
-     `is_component_build` makes it possible to create shared libraries instead
-     of static libraries.
-     If an app depends on WebRTC it makes sense to just depend on the WebRTC
-     static library, so there is no difference between `is_component_build=true`
-     and `is_component_build=false`.
-
   2. Compile using:
 
      ~~~~~ bash

--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -121,4 +121,3 @@ location as the native tests described in the previous section.
 [2]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/api/java/README
 [3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/androidapp/README
 [4]: https://ninja-build.org/
-[5]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md

--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -49,6 +49,16 @@ the code, building etc.
       * To build for 32-bit x86: use `target_cpu="x86"`
       * To build for 64-bit x64: use `target_cpu="x64"`
 
+     **NOTICE: Component Builds are not supported**
+
+     The Gn arg `is_component_build` is currently ignored for WebRTC builds.
+     [Component builds][5] are supported by Chromium and the arg
+     `is_component_build` makes it possible to create shared libraries instead
+     of static libraries.
+     If an app depends on WebRTC it makes sense to just depend on the WebRTC
+     static library, so there is no difference between `is_component_build=true`
+     and `is_component_build=false`.
+
   2. Compile using:
 
      ~~~~~ bash
@@ -121,3 +131,4 @@ location as the native tests described in the previous section.
 [2]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/api/java/README
 [3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/androidapp/README
 [4]: https://ninja-build.org/
+[5]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md

--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -51,8 +51,8 @@ the code, building etc.
 
      **NOTICE: Component Builds are not supported**
 
-     The Gn arg `is_component_build` is currently ignored for WebRTC builds.
-     [Component builds][5] are supported by Chromium and the arg
+     The Gn argument `is_component_build` is currently ignored for WebRTC builds.
+     [Component builds][5] are supported by Chromium and the argument
      `is_component_build` makes it possible to create shared libraries instead
      of static libraries.
      If an app depends on WebRTC it makes sense to just depend on the WebRTC

--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -101,10 +101,6 @@ the src/ directory of your checkout):
 gn gen out/Default
 ~~~~~
 
-**NOTICE:** Debug builds are [component builds][14] (shared libraries) by
-default unless `is_component_build=false` is passed to `gn gen --args`.
-Release builds are static by default.
-
 To generate ninja project files for a Release build instead:
 
 ~~~~~ bash
@@ -120,6 +116,16 @@ gn clean out/Default
 
 See the [GN][12] documentation for all available options. There are also more
 platform specific tips on the [Android][1] and [iOS][2] pages.
+
+**NOTICE: Component Builds are not supported**
+
+The Gn arg `is_component_build` is currently ignored for WebRTC builds.
+[Component builds][15] are supported by Chromium and the arg
+`is_component_build` makes it possible to create shared libraries instead
+of static libraries.
+If an app depends on WebRTC it makes sense to just depend on the WebRTC static
+library, so there is no difference between `is_component_build=true` and
+`is_component_build=false`.
 
 
 #### Compiling
@@ -359,5 +365,6 @@ Target name `turnserver`. In active development to reach compatibility with
 [12]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/README.md
 [13]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/reference.md#IDE-options
 [14]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md
+[15]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md
 [RFC 5389]: https://tools.ietf.org/html/rfc5389
 [RFC 5766]: https://tools.ietf.org/html/rfc5766

--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -119,8 +119,8 @@ platform specific tips on the [Android][1] and [iOS][2] pages.
 
 **NOTICE: Component Builds are not supported**
 
-The Gn arg `is_component_build` is currently ignored for WebRTC builds.
-[Component builds][15] are supported by Chromium and the arg
+The Gn argument `is_component_build` is currently ignored for WebRTC builds.
+[Component builds][15] are supported by Chromium and the argument
 `is_component_build` makes it possible to create shared libraries instead
 of static libraries.
 If an app depends on WebRTC it makes sense to just depend on the WebRTC static

--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -353,7 +353,5 @@ Target name `turnserver`. In active development to reach compatibility with
 [11]: https://bugs.chromium.org/p/webrtc/issues/detail?id=5578
 [12]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/README.md
 [13]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/reference.md#IDE-options
-[14]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md
-[15]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md
 [RFC 5389]: https://tools.ietf.org/html/rfc5389
 [RFC 5766]: https://tools.ietf.org/html/rfc5766

--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -117,17 +117,6 @@ gn clean out/Default
 See the [GN][12] documentation for all available options. There are also more
 platform specific tips on the [Android][1] and [iOS][2] pages.
 
-**NOTICE: Component Builds are not supported**
-
-The Gn argument `is_component_build` is currently ignored for WebRTC builds.
-[Component builds][15] are supported by Chromium and the argument
-`is_component_build` makes it possible to create shared libraries instead
-of static libraries.
-If an app depends on WebRTC it makes sense to just depend on the WebRTC static
-library, so there is no difference between `is_component_build=true` and
-`is_component_build=false`.
-
-
 #### Compiling
 
 When you have Ninja project files generated (see previous section), compile

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -189,4 +189,3 @@ For instructions on how to do this see [here][7]
 [5]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/README.md
 [6]: https://github.com/phonegap/ios-deploy
 [7]: http://ikennd.ac/blog/2015/02/stripping-unwanted-architectures-from-dynamic-libraries-in-xcode/
-[8]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -62,10 +62,6 @@ The variables you should care about are the following:
   - For builds targeting iOS devices, this should be set to either `"arm"` or
   `"arm64"`, depending on the architecture of the device. For builds to run in
   the simulator, this should be set to `"x64"`.
-* `is_component_build`:
-  - Component builds don't take as long to link, but have runtime performance
-  implications. They are not supported on iOS, so this should always be set
-  to `false`.
 * `is_debug`:
   - Debug builds are the default. When building for release, specify `false`.
 
@@ -85,11 +81,21 @@ with the new arguments.
 
 ~~~~~ bash
 # debug build for 64-bit iOS
-gn gen out/ios_64 --args='target_os="ios" target_cpu="arm64" is_component_build=false'
+gn gen out/ios_64 --args='target_os="ios" target_cpu="arm64"'
 
 # debug build for simulator
-gn gen out/ios_sim --args='target_os="ios" target_cpu="x64" is_component_build=false'
+gn gen out/ios_sim --args='target_os="ios" target_cpu="x64"'
 ~~~~~
+
+**NOTICE: Component Builds are not supported**
+
+The Gn arg `is_component_build` is currently ignored for WebRTC builds.
+[Component builds][8] are supported by Chromium and the arg
+`is_component_build` makes it possible to create shared libraries instead
+of static libraries.
+If an app depends on WebRTC it makes sense to just depend on the WebRTC static
+library, so there is no difference between `is_component_build=true` and
+`is_component_build=false`.
 
 ### Compiling with ninja
 
@@ -117,7 +123,7 @@ placed in your specified output directory.
 Example:
 
 ~~~~~ bash
-gn gen out/ios --args='target_os="ios" target_cpu="arm64" is_component_build=false' --ide=xcode
+gn gen out/ios --args='target_os="ios" target_cpu="arm64"' --ide=xcode
 open -a Xcode.app out/ios/all.xcworkspace
 ~~~~~
 
@@ -193,3 +199,4 @@ For instructions on how to do this see [here][7]
 [5]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/README.md
 [6]: https://github.com/phonegap/ios-deploy
 [7]: http://ikennd.ac/blog/2015/02/stripping-unwanted-architectures-from-dynamic-libraries-in-xcode/
+[8]: https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -89,8 +89,8 @@ gn gen out/ios_sim --args='target_os="ios" target_cpu="x64"'
 
 **NOTICE: Component Builds are not supported**
 
-The Gn arg `is_component_build` is currently ignored for WebRTC builds.
-[Component builds][8] are supported by Chromium and the arg
+The Gn argument `is_component_build` is currently ignored for WebRTC builds.
+[Component builds][8] are supported by Chromium and the argument
 `is_component_build` makes it possible to create shared libraries instead
 of static libraries.
 If an app depends on WebRTC it makes sense to just depend on the WebRTC static

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -87,16 +87,6 @@ gn gen out/ios_64 --args='target_os="ios" target_cpu="arm64"'
 gn gen out/ios_sim --args='target_os="ios" target_cpu="x64"'
 ~~~~~
 
-**NOTICE: Component Builds are not supported**
-
-The Gn argument `is_component_build` is currently ignored for WebRTC builds.
-[Component builds][8] are supported by Chromium and the argument
-`is_component_build` makes it possible to create shared libraries instead
-of static libraries.
-If an app depends on WebRTC it makes sense to just depend on the WebRTC static
-library, so there is no difference between `is_component_build=true` and
-`is_component_build=false`.
-
 ### Compiling with ninja
 
 To compile, just run ninja on the appropriate target. For example:


### PR DESCRIPTION
Component builds are not supported by the WebRTC build.
This pull request fixes the documentation with a notice in all the
three pages under 'Native Code'.

Not supporting component builds means that there is no difference
between is_component_build=true and is_component_build=false.

To support this Gn argument we should update all the BUILD.gn files to use
the target type 'component' instead of 'rtc_static_library'/'rtc_shared_library'.
This would give Gn the power to generate shared libraries or static libraries
looking at the value of 'is_component_build'.

This is a non trivial effort and we don't think that the generation
of single WebRTC shared "sub-libraries" is common enough to justify the effort.

These targets are still available on their own but their type is statically
declared in the BUILD.gn file.