### PR TITLE
Remove stale hyperlinks

### DIFF
--- a/_posts/2012-03-05-source-code-to-apprtc.appspot.com-example-app-available.md
+++ b/_posts/2012-03-05-source-code-to-apprtc.appspot.com-example-app-available.md
@@ -7,7 +7,7 @@ date: 2012-03-05 14:21:00
 
 
 The source code to <https://apprtc.appspot.com/> is now available at
-<https://chromium.googlesource.com/external/webrtc/+/master/talk/examples/android/src/org/appspot/apprtc/>
+https://chromium.googlesource.com/external/webrtc/+/master/talk/examples/android/src/org/appspot/apprtc/ (link outdated).
 
 Our goal is to keep this app updated to work with the latest Chrome code and
 to keep the code simple enough for everyone to use as an example or to simply

--- a/_posts/2012-03-05-source-code-to-apprtc.appspot.com-example-app-available.md
+++ b/_posts/2012-03-05-source-code-to-apprtc.appspot.com-example-app-available.md
@@ -7,7 +7,7 @@ date: 2012-03-05 14:21:00
 
 
 The source code to <https://apprtc.appspot.com/> is now available at
-https://chromium.googlesource.com/external/webrtc/+/master/talk/examples/android/src/org/appspot/apprtc/ (link outdated).
+<https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/androidapp/src/org/appspot/apprtc>.
 
 Our goal is to keep this app updated to work with the latest Chrome code and
 to keep the code simple enough for everyone to use as an example or to simply

--- a/license/ilbc-freeware/ilbc-extra-documentation/index.md
+++ b/license/ilbc-freeware/ilbc-extra-documentation/index.md
@@ -33,12 +33,10 @@ when new versions of the drafts were presented and discussed:
     [draft-andersen-ilbc-01.txt][5]
 
   * IETF 55 meeting, Atlanta:
-    [presentation of the updated version of both drafts][6]
     [draft-ietf-avt-rtp-ilbc-00.txt][7] and
     [draft-ietf-avt-ilbc-codec-00.txt][8]
 
   * IETF 56 meeting, San Francisco:
-    [presentation of the updated version of both drafts][9]
     [draft-ietf-avt-rtp-ilbc-01.txt][10] and
     [draft-ietf-avt-ilbc-codec-01.txt][11]
 
@@ -47,10 +45,8 @@ when new versions of the drafts were presented and discussed:
 [3]: http://www.ietf.org/proceedings/02jul/slides/avt-8.pdf
 [4]: http://tools.ietf.org/html/draft-duric-rtp-ilbc-01
 [5]: http://tools.ietf.org/html/draft-andersen-ilbc-01
-[6]: http://www.ilbcfreeware.org/documentation/ietf55-avt-duric.pdf
 [7]: http://tools.ietf.org/html/draft-ietf-avt-rtp-ilbc-00
 [8]: http://tools.ietf.org/html/draft-ietf-avt-ilbc-codec-00
-[9]: http://www.ilbcfreeware.org/documentation/ietf56-avt-duric.pdf
 [10]: http://tools.ietf.org/html/draft-ietf-avt-rtp-ilbc-01
 [11]: http://tools.ietf.org/html/draft-ietf-avt-ilbc-codec-01
 

--- a/start/index.md
+++ b/start/index.md
@@ -139,7 +139,7 @@ More resources below.
 * Xylophone: [soundstep.com/blog/experiments/jsdetection](http://soundstep.com/blog/experiments/jsdetection)
 * Photobooth with filters: [webcamtoy.com](http://webcamtoy.com)
 * SVG filters: [rawgithub.com/SenorBlanco/moggy/master/filterbooth.html](https://rawgithub.com/SenorBlanco/moggy/master/filterbooth.html)
-* Face masking with WebGL:[auduno.github.io/clmtrackr/face\_mask.html](http://auduno.github.io/clmtrackr/face_mask.html)
+* Face masking with WebGL:[www.auduno.com/clmtrackr/examples/face_mask.html](https://www.auduno.com/clmtrackr/examples/face_mask.html)
 * Face deformation with WebGL: [auduno.github.io/clmtrackr/examples/facedeform.html](http://auduno.github.io/clmtrackr/examples/facedeform.html)
 * Augmented Reality Photobooth: [picshare.jooink.com](https://picshare.jooink.com/)
 

--- a/web-apis/index.md
+++ b/web-apis/index.md
@@ -15,8 +15,6 @@ developers to develop web applications using WebRTC technology:
     Between Browsers
   * <http://w3c.github.io/mediacapture-main/> - Media Capture and Streams
 
-See also the [webplatform.org documentation][1].
-
 
 ### Subpage Listing
 
@@ -25,5 +23,3 @@ See also the [webplatform.org documentation][1].
   * [Firefox](firefox)
   * [Interop Notes](interop)
   * [Standardization](standardization)
-
-[1]: http://docs.webplatform.org/wiki/apis/webrtc


### PR DESCRIPTION
Remove/update some broken link targets (#131)
    
These stale outbound links seem safe to remove, update or annotate.
    
The remaining stale targets *may* have valuable replacements that I'm unable to identify. Someone more knowledgeable should take a look.