### PR TITLE
Add 'gclient sync' after switching to a WebRTC branch

### DIFF
--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -169,6 +169,7 @@ the 43 branch):
 
 ~~~~~ bash
 git checkout -b my_branch refs/remotes/branch-heads/43
+gclient sync
 ~~~~~
 
 Commit log for the branch:


### PR DESCRIPTION
This will avoid misunderstandings like https://bugs.chromium.org/p/webrtc/issues/detail?id=7762