### PR TITLE
Add note about enabling debug log from Android code

### DIFF
--- a/native-code/logging/index.md
+++ b/native-code/logging/index.md
@@ -43,6 +43,9 @@ Logged to Android system log. Can be obtained using:
 adb logcat -s "libjingle"
 ~~~~
 
+To enable the logging in a non-debug build from Java code, use
+`Logging.enableLogToDebugOutput(Logging.Severity.LS_INFO)`.
+
 #### iOS
 
 Only logged to `stderr` by default. To log to a file, use `RTCFileLogger`.


### PR DESCRIPTION
Had to grep the source code to find this :) Existing docs are just about the C++ code.