### PR TITLE
Add --canary flag to Android project generation instructions.

### DIFF
--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -91,7 +91,7 @@ For instructions on how to build and run, see
      ~~~~~ bash
      build/android/gradle/generate_gradle.py --output-directory $PWD/out/Debug \
      --target "//webrtc/examples:AppRTCMobile" --use-gradle-process-resources \
-     --split-projects
+     --split-projects --canary
      ~~~~~
 
   3. *Import* the project in Android Studio. (Do not just open it.) The project


### PR DESCRIPTION
This new flag will be needed as we start using Java 8 features.