### PR TITLE
Update all repo URLs to new source-of-truth host.

### DIFF
--- a/_posts/2012-03-05-source-code-to-apprtc.appspot.com-example-app-available.md
+++ b/_posts/2012-03-05-source-code-to-apprtc.appspot.com-example-app-available.md
@@ -7,7 +7,7 @@ date: 2012-03-05 14:21:00
 
 
 The source code to <https://apprtc.appspot.com/> is now available at
-<https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/androidapp/src/org/appspot/apprtc>.
+<https://webrtc.googlesource.com/src/+/master/webrtc/examples/androidapp/src/org/appspot/apprtc>.
 
 Our goal is to keep this app updated to work with the latest Chrome code and
 to keep the code simple enough for everyone to use as an example or to simply

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -27,7 +27,7 @@ when you have found a bug and have implemented a fix for it.
 
 Google and the WebRTC team are committed to preserving and fostering a diverse, welcoming and open
 community.
-To make sure we preserve this, we have adopted a [Code of conduct](https://chromium.googlesource.com/external/webrtc/+/master/CODE_OF_CONDUCT.md).
+To make sure we preserve this, we have adopted a [Code of conduct](https://webrtc.googlesource.com/src/+/master/CODE_OF_CONDUCT.md).
 
 ## How to Create a Patch
 
@@ -73,7 +73,7 @@ back to you with the continuous build result.
 
 See the [coding style guide in the WebRTC tree][webrtc-coding-style].
 
-[webrtc-coding-style]: https://chromium.googlesource.com/external/webrtc/+/HEAD/style-guide.md
+[webrtc-coding-style]: https://webrtc.googlesource.com/src/+/HEAD/style-guide.md
 
 To format the code in a CL, you can use `git cl format`.
 To manually run the C++ lint checker, use `cpplint.py`.
@@ -234,9 +234,9 @@ how to commit the CL.
 [2]: https://cla.developers.google.com/about/google-corporate
 [3]: https://codereview.webrtc.org/
 [4]: http://www.chromium.org/developers/owners-files
-[5]: https://chromium.googlesource.com/external/webrtc/+/master/infra/config/cq.cfg
+[5]: https://webrtc.googlesource.com/src/+/master/infra/config/cq.cfg
 [6]: https://build.chromium.org/p/chromium.webrtc.fyi/waterfall
 [7]: https://code.google.com/p/chromium/codesearch#chromium/src/DEPS
-[9]: https://chromium.googlesource.com/external/webrtc/+/master/AUTHORS
+[9]: https://webrtc.googlesource.com/src/+/master/AUTHORS
 [10]: https://bugs.webrtc.org
 [11]: https://crbug.com

--- a/faq/index.md
+++ b/faq/index.md
@@ -106,7 +106,7 @@ connection using ICE / STUN / Turn / RTP-over-TCP and support for proxies.
 
 ### How do I access the WebRTC code?
 
-Go to <https://chromium.googlesource.com/external/webrtc>
+Go to <https://webrtc.googlesource.com/src>
 
 
 ### How can I test the quality of WebRTC components?

--- a/index.md
+++ b/index.md
@@ -124,8 +124,8 @@ Lots more resources for getting started are available from [webrtc.org/start](ht
     <ul>
       <li>
         <p>The master <strong>source repository</strong> for WebRTC is at
-        <a href="https://chromium.googlesource.com/external/webrtc">
-        https://chromium.googlesource.com/external/webrtc</a> (check
+        <a href="https://webrtc.googlesource.com/src">
+        https://webrtc.googlesource.com/src</a> (check
         <a href="{{ site.baseurl }}/native-code/development/">Development</a>
         for more details).</p>
       </li>

--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -151,6 +151,6 @@ location as the native tests described in the previous section.
 
 
 [1]: {{ site.baseurl }}/native-code/development/prerequisite-sw/
-[2]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/sdk/android/README
-[3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/androidapp/README
+[2]: https://webrtc.googlesource.com/src/+/master/webrtc/sdk/android/README
+[3]: https://webrtc.googlesource.com/src/+/master/webrtc/examples/androidapp/README
 [4]: https://ninja-build.org/

--- a/native-code/development/index.md
+++ b/native-code/development/index.md
@@ -173,10 +173,10 @@ gclient sync
 ~~~~~
 
 Commit log for the branch:
-<https://chromium.googlesource.com/external/webrtc/+log/branch-heads/43>
+<https://webrtc.googlesource.com/src/+log/branch-heads/43>
 
 To browse it:
-<https://chromium.googlesource.com/external/webrtc/+/branch-heads/43>
+<https://webrtc.googlesource.com/src/+/branch-heads/43>
 
 For more details, read Chromium's [Working with Branches][6] and
 [Working with Release Branches][7] pages.
@@ -195,7 +195,7 @@ To commit code directly to the Git repo, you have to be a committer. CLs created
 by external contributors can be committed via the Commit Queue (CQ).
 
 The source of truth is the Git repository at
-<https://chromium.googlesource.com/external/webrtc>. To be able to push
+<https://webrtc.googlesource.com/src>. To be able to push
 commits to it, you need to perform the steps below (assuming you're a
 committer).
 
@@ -344,7 +344,7 @@ Target name `turnserver`. In active development to reach compatibility with
 [1]: {{ site.baseurl }}/native-code/android/
 [2]: {{ site.baseurl }}/native-code/ios/
 [3]: {{ site.baseurl }}/native-code/development/prerequisite-sw/
-[4]: https://chromium.googlesource.com/external/webrtc/+/master/DEPS
+[4]: https://webrtc.googlesource.com/src/+/master/DEPS
 [5]: https://ninja-build.org/
 [6]: https://www.chromium.org/developers/how-tos/get-the-code/working-with-branches
 [7]: https://www.chromium.org/developers/how-tos/get-the-code/working-with-release-branches

--- a/native-code/index.md
+++ b/native-code/index.md
@@ -12,11 +12,11 @@ API](http://dev.w3.org/2011/webrtc/editor/webrtc.html) instead.
 
 The WebRTC **native code package** can be found at:
 
-  * <https://chromium.googlesource.com/external/webrtc>
+  * <https://webrtc.googlesource.com/src>
 
 The **change log** is at:
 
-  * <https://chromium.googlesource.com/external/webrtc/+log>
+  * <https://webrtc.googlesource.com/src/+log>
 
 Please read the [**License & Rights**]({{ site.baseurl }}/license/) and
 [**FAQ**]({{ site.baseurl }}/faq/) before downloading the source code.

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -184,7 +184,7 @@ For instructions on how to do this see [here][7]
 
 [1]: {{ site.baseurl }}/native-code/development/prerequisite-sw/
 [2]: {{ site.baseurl }}/native-code/development/
-[3]: https://chromium.googlesource.com/external/webrtc/+/master/tools_webrtc/ios/build_ios_libs.py
+[3]: https://webrtc.googlesource.com/src/+/master/tools_webrtc/ios/build_ios_libs.py
 [4]: https://ninja-build.org/
 [5]: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/README.md
 [6]: https://github.com/phonegap/ios-deploy

--- a/native-code/native-apis/index.md
+++ b/native-code/native-apis/index.md
@@ -23,8 +23,8 @@ APIs to implement WebRTC JavaScript APIs or to develop native RTC
 applications.
 
 [1]: http://w3c.github.io/webrtc-pc/
-[2]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/api/
-[3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples/peerconnection
+[2]: https://webrtc.googlesource.com/src/+/master/webrtc/api/
+[3]: https://webrtc.googlesource.com/src/+/master/webrtc/examples/peerconnection
 
 
 
@@ -70,9 +70,9 @@ The worker thread is used to handle more resource-intensive processes, such as
 data streaming.
 
 
-  * Stream APIs ([mediastreaminterface.h](https://chromium.googlesource.com/external/webrtc/+/master/webrtc/api/mediastreaminterface.h))
+  * Stream APIs ([mediastreaminterface.h](https://webrtc.googlesource.com/src/+/master/webrtc/api/mediastreaminterface.h))
 
-  * PeerConnection APIs ([peerconnectioninterface.h](https://chromium.googlesource.com/external/webrtc/+/master/webrtc/api/peerconnectioninterface.h))
+  * PeerConnection APIs ([peerconnectioninterface.h](https://webrtc.googlesource.com/src/+/master/webrtc/api/peerconnectioninterface.h))
 
 
 
@@ -85,8 +85,8 @@ The current HTML5 specification for WebRTC is here:
 
 The source code of the WebRTC Native API is here:
 
-<https://chromium.googlesource.com/external/webrtc/+/master/webrtc/api>
+<https://webrtc.googlesource.com/src/+/master/webrtc/api>
 
 Client and server sample apps can be found here:
 
-<https://chromium.googlesource.com/external/webrtc/+/master/webrtc/examples>
+<https://webrtc.googlesource.com/src/+/master/webrtc/examples>

--- a/testing/continuous/index.md
+++ b/testing/continuous/index.md
@@ -80,7 +80,7 @@ See the [Conformance testing]({{ site.baseurl }}/testing/conformance/) page.
 
 [1]: http://bugs.webrtc.org
 [2]: http://build.chromium.org/p/client.webrtc/waterfall
-[3]: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/BUILD.gn#568
+[3]: https://webrtc.googlesource.com/src/+/master/webrtc/BUILD.gn#568
 [4]: https://cs.chromium.org/chromium/src/chrome/browser/media/webrtc/webrtc_browsertest.cc
 [5]: https://cs.chromium.org/chromium/src/content/browser/webrtc/webrtc_browsertest.cc
 [6]: https://code.google.com/p/chromium/codesearch#chromium/src/content/test/data/media/peerconnection-call.html&q=peerconn&sq=package:chromium&l=1


### PR DESCRIPTION
What used to be
https://chromium.googlesource.com/external/webrtc is now
https://webrtc.googlesource.com/src and the old one is deprecated.