### PR TITLE
Fix broken links from WebRTC homepage.

### DIFF
--- a/start/index.md
+++ b/start/index.md
@@ -167,7 +167,6 @@ More resources below.
 * [browsermeeting.com](http://browsermeeting.com/)
 * [codassium.com](http://codassium.com/): job interview tool with live coding
 * [vmux.co](http://vmux.co)
-* [vidtok.com](http://vidtok.com)
 * [voxeet.com](https://voxeet.com/): high quality audio
 
 #### Games
@@ -185,10 +184,8 @@ More resources below.
 
 #### File sharing and P2P
 * [Sharefest](http://sharefest.me): share file by uploading and sharing link
-* [dropple.me](http://dropple.me): get a file by sending a link to a share page
 * [peerCDN](https://peercdn.com/): P2P CDN
 * [WebTorrent:](http://webtorrent.io) BitTorrent over WebRTC
-* [cdn.peer5.com/pilots/kaltura](http://cdn.peer5.com/pilots/kaltura/index.html): P2P video
 * [webp2p.org](http://webp2p.org/)
 * [peer5.com](https://peer5.com): add P2P file download to your web page
 


### PR DESCRIPTION
Description:
Fix Dead Links at the Start Page

Resolution: 
Removed http://vidtok.com, 
Removed http://dropple.me and 
Removed http://cdn.peer5.com/pilots/kaltura/index.html