### PR TITLE
Attempt to fix push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ env:
   - CLOUDSDK_CORE_DISABLE_PROMPTS=1
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speed up html-proofer install
 
+before_install:
+- if [ ! -d ${HOME}/google-cloud-sdk ]; then
+     curl https://sdk.cloud.google.com | bash;
+  fi
+
 cache:
   bundler: true
   directories:


### PR DESCRIPTION
Looks like the cloud sdk happened to be on the machines earlier, but it's not now. This should take care of that.

I tested the bash command locally, appears to work.