### PR TITLE
Don't cache cloud sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ env:
   - CLOUDSDK_CORE_DISABLE_PROMPTS=1
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speed up html-proofer install
 
+# Run the install script, but suppress tar output since excessive output
+# makes Travis choke.
 before_install:
 - if [ ! -d ${HOME}/google-cloud-sdk ]; then
-     curl https://sdk.cloud.google.com | bash;
+     curl https://sdk.cloud.google.com | bash | grep -v google-cloud-sdk;
   fi
 
 cache:
   bundler: true
-  directories:
-  - "$HOME/google-cloud-sdk/"
 
 # See the following for more details:
 # https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches


### PR DESCRIPTION
It's error prone and doesn't save a lot of time anyway