### PR TITLE
Added KITE testing development page

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -44,6 +44,7 @@
               <li><a href="{{ site.baseurl }}/testing/continuous/">Continuous Testing</a></li>
               <li><a href="{{ site.baseurl }}/testing/conformance/">Conformance Testing</a></li>
               <li><a href="{{ site.baseurl }}/testing/wireshark/">Testing with Wireshark</a></li>
+              <li><a href="{{ site.baseurl }}/testing/kite/">Testing with KITE</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/testing/kite/index.md
+++ b/testing/kite/index.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Testing with Kite
+permalink: /testing/kite/
+---
+
+
+{% include toc-hide.html %}
+
+
+## This is Karoshi Interoperability Testing Engine (KITE)
+
+
+The effortless way to test WebRTC compliance, prevent [Karoshi](https://en.wikipedia.org/wiki/Kar%C5%8Dshi) with KITE!
+
+KITE is designed to be a generic, reusable and easy to maintain automated testing environment.
+
+So far, our developments on KITE allow interoperability testing on stable versions of all major web browsers, namely Chrome, Firefox, Safari and Edge, running on desktop OS, that is either Ubuntu, MacOS or Windows 10.
+
+Mobile testing (Chrome,Firefox on Android, Safari on iOS) is soon to be operational.
+
+### Development:
+
+Check out KITE on [webrtc/KITE public repository](https://github.com/webrtc/KITE).
+
+### Included sample IceConnectionTest test
+
+IceConnectionTest algorithm is as follows:
+
+    1) Open the 2 browsers with https://appr.tc/r/xxx.
+
+    2) Click 'confirm-join-button' for both of the browsers in sequence.
+
+    3) Do the following every 1 second for 1 minute for both the browsers:
+
+        a) Retreive iceConnectionState.
+
+        b) Checks whether both the browsers'iceConnectionState is either 'completed' or 'connected'.
+
+    4) The test is considered as successful if all the browsers either returns 'completed' or 'connected' within 1 minute.
+
+
+### Simple result Dashboard for KITE tests:
+
+
+<iframe width="100%" height="1200" src="https://kiteboard.herokuapp.com/public" frameborder="0" scrolling="no"></iframe>
+

--- a/testing/kite/index.md
+++ b/testing/kite/index.md
@@ -7,25 +7,22 @@ permalink: /testing/kite/
 
 {% include toc-hide.html %}
 
+### Development:
 
-## This is Karoshi Interoperability Testing Engine (KITE)
+KITE is an open source test tool to test interoperability of WebRTC across browsers. KITE makes it easy to test interoperability of WebRTC applications and detect regressions early.
 
-
-The effortless way to test WebRTC compliance, prevent [Karoshi](https://en.wikipedia.org/wiki/Kar%C5%8Dshi) with KITE!
-
-KITE is designed to be a generic, reusable and easy to maintain automated testing environment.
+KITE is designed to be a generic, reusable and easy to maintain automated testing environment. The tests (implementing KiteTest interface) can be developed independently from the KITE Engine.
 
 So far, our developments on KITE allow interoperability testing on stable versions of all major web browsers, namely Chrome, Firefox, Safari and Edge, running on desktop OS, that is either Ubuntu, MacOS or Windows 10.
 
-Mobile testing (Chrome,Firefox on Android, Safari on iOS) is soon to be operational.
+Mobile testing (Chrome,Firefox on Android, Safari on iOS) is well in development.
 
-### Development:
 
-Check out KITE on [webrtc/KITE public repository](https://github.com/webrtc/KITE).
+You can check out the source for KITE and run your own tests [here](https://github.com/webrtc/KITE).
 
-### Included sample IceConnectionTest test
+### Included sample IceConnectionTest
 
-IceConnectionTest algorithm is as follows:
+The Ice Connection test is a basic test showing that two browsers can establish a connection. IceConnectionTest's algorithm is as follows:
 
     1) Open the 2 browsers with https://appr.tc/r/xxx.
 

--- a/web-apis/interop/index.md
+++ b/web-apis/interop/index.md
@@ -42,3 +42,7 @@ AppRTC ([appr.tc](https://appr.tc)) uses the adapter.js polyfill, so it
 correctly handles interop between the browsers. You can test this with Chrome
 and Firefox today! This is tested continuously by our
 [automated Chrome-Firefox interop tests]({{ site.baseurl }}/testing/conformance/).
+
+### Testing with KITE
+
+KITE is an open-source testing Engine, designed to test interoperability between browsers, more information [here]({{ site.baseurl }}/testing/kite/).


### PR DESCRIPTION
Added Testing with KITE tab in development drop-down in nav-bar.

Added KITE testing page, with an iframe referring to a public facing dashboard for KITE tests' results