### PR TITLE
Unified Plan: Announce the time

### DIFF
--- a/web-apis/chrome/index.md
+++ b/web-apis/chrome/index.md
@@ -14,6 +14,12 @@ for Windows, Linux, Mac and Android.
 
 ### FAQ about the current implementation
 
+### What's the status of Unified Plan SDP?
+
+Chrome is in the process of transitioning from the old, non-standard SDP
+called "plan b" to the standardized format called "Unified Plan".
+
+Details of this transition are found in the [Unified Plan document](unified-plan).
 
 #### What's the status of data channels?
 

--- a/web-apis/chrome/unified-plan/index.md
+++ b/web-apis/chrome/unified-plan/index.md
@@ -34,7 +34,7 @@ Unified Plan is currently developed, and the flag for experimentation has been a
 If you run Chrome with “--enable-blink-features=RTCUnifiedPlan”, you will have access to the “sdpSemantics” feature described above, and can start testing with Unified Plan.
 
 ### Phase 2: Make the API feature generally available
-Planned for M68 (beta June 2018).
+Released in M69 (beta August 2018, stable September 2018)
 
 In this phase, the default value of the sdpSemantics flag is “plan-b”.
 In Phase 2, we expect people who have implementations that depend on the SDP format to run tests to see if their applications work when Unified Plan is in use.
@@ -42,13 +42,20 @@ For applications that support Firefox, we expect this to be a very simple exerci
 
 ### Phase 3: Switch the default
 
-The date for the switch will be set in consultation with the users, after extensive testing.
+The date for the switch will be set in consultation with the users, after extensive testing. Our current plan is M72 (beta December 2018, stable January 2019). 
 
 In this phase, we’ll change the default value of the sdpSemantics flag to “unified-plan”.
 Applications that discover that they need more time to convert can set the sdpSemantics flag explicitly to “plan-b” in order to recover previous behaviour.
+
+As part of testing, we expect to try changing the default value of the flag in Canary multiple times over the development cycle of M71 and M72.
 
 We will be monitoring the usage of the flag, and the amount of SDP being received with “Plan B” semantics, in order to set the date for phase 4.
 ### Phase 4: Remove “plan B”
 
 In this phase, the sdpSemantics flag and all code for supporting Plan B will be removed from Chrome. Setting the sdpSemantics flag will not be an error, but will have no effect.
 
+## Further information
+
+For information on Unified Plan in the C++ API, see the [C++ API transition plan](TBD).
+
+For detailed information on how to modify your application for Unified plan, see the [Web API transition guide](TBD).

--- a/web-apis/chrome/unified-plan/index.md
+++ b/web-apis/chrome/unified-plan/index.md
@@ -26,7 +26,7 @@ partial dictionary RTCConfiguration {
 ```
 The RTCConfiguration can be passed to the constructor of an RTCPeerConnection, and all offers and answers constructed will be in the Unified Plan format. Calls to setLocalDescription and setRemoteDescription will also expect the SDP to be in the Unified Plan format; if it is in the legacy Chrome format, then all but the first audio track and the first video track will be ignored.
 
-There’s also a command line flag (--enable-blink-features=RTCUnifiedPlanByDefault) that allows the default value of this flag to be set to “unified-plan”.
+There’s also a command line flag (--enable-features=RTCUnifiedPlanByDefault in M71 and above, --enable-blink-features=RTCUnifiedPlanByDefault in earlier versions) that allows the default value of this flag to be set to “unified-plan”.
 ## The Phases
 
 ### Phase 1: Implement Unified Plan
@@ -39,6 +39,8 @@ Released in M69 (beta August 2018, stable September 2018)
 In this phase, the default value of the sdpSemantics flag is “plan-b”.
 In Phase 2, we expect people who have implementations that depend on the SDP format to run tests to see if their applications work when Unified Plan is in use.
 For applications that support Firefox, we expect this to be a very simple exercise: just do as you would do for Firefox.
+
+The default value of the sdpSemantics flag can be changed in "chrome://flags"; look for the feature "WebRTC: Use Unified Plan SDP Semantics by default".
 
 ### Phase 3: Switch the default
 
@@ -56,6 +58,6 @@ In this phase, the sdpSemantics flag and all code for supporting Plan B will be 
 
 ## Further information
 
-For information on Unified Plan in the C++ API, see the [C++ API transition plan](TBD).
+For information on Unified Plan in the C++ API, see the C++ API transition plan (forthcoming).
 
-For detailed information on how to modify your application for Unified plan, see the [Web API transition guide](TBD).
+For detailed information on how to modify your application for Unified plan, see the Web API transition guide (forthcoming).


### PR DESCRIPTION
Add the release at which we intend to flip the flag.
Add reference to transition guide and C++ info (as TBD).
Make the page findable from the top level.