### PR TITLE
Add some info about how bug entries are well-formed in commit message

### DIFF
--- a/contributing/index.md
+++ b/contributing/index.md
@@ -59,8 +59,14 @@ Now that you have your account set up, you can do the actual upload:
      git cl upload
      ~~~~~
      This will open a text editor showing all local commit messages, allowing you
-     to modify it before it becomes the CL description. Save and close the file to
-     proceed with the upload to the WebRTC [code review server][3].
+     to modify it before it becomes the CL description.
+
+     Fill out the bug entry properly. Please specify the issue tracker prefix and
+     the issue number, separated by a colon, e.g. webrtc:123 or chromium:12345.
+     If you do not have an issue tracker prefix and an issue number just add
+     `None`.
+
+     Save and close the file to proceed with the upload to the WebRTC [code review server][3].
 
      The command will print a link like <https://webrtc-review.googlesource.com/c/src/+/53121>
      if everything goes well.
@@ -70,22 +76,18 @@ Now that you have your account set up, you can do the actual upload:
   3. If you're not signed in, click the Sign In button in the top right and sign
   in with your email.
 
-  4. Fill out the bug entry properly. Please specify the issue tracker prefix and
-  the issue number, separated by a colon, e.g. webrtc:123 or chromium:12345. If
-  you do not have an issue tracker prefix and an issue number just add `None`.
-
-  5. Click Start Review and add a reviewer. See
+  4. Click Start Review and add a reviewer. See
   [Getting your CL Reviewed](#getting-your-cl-reviewed) for how to choose
   reviewers.
 
-  6. Address any reviewer feedback:
+  5. Address any reviewer feedback:
      ~~~~~ bash
      # Make changes, build locally, run tests locally
      git commit -am "Fixed X and Y"
      git cl upload
      ~~~~~
 
-  7. Once the reviewer LGTMs (approves) the patch, ask them to put it into the
+  6. Once the reviewer LGTMs (approves) the patch, ask them to put it into the
   commit queue.
 
 **NOTICE:** On Windows, you'll need to run the above in a Git bash shell in order

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -70,18 +70,22 @@ Now that you have your account set up, you can do the actual upload:
   3. If you're not signed in, click the Sign In button in the top right and sign
   in with your email.
 
-  4. Click Start Review and add a reviewer. See
+  4. Fill out the bug entry properly. Please specify the issue tracker prefix and
+  the issue number, separated by a colon, e.g. webrtc:123 or chromium:12345. If
+  you do not have an issue tracker prefix and an issue number just add `None`.
+
+  5. Click Start Review and add a reviewer. See
   [Getting your CL Reviewed](#getting-your-cl-reviewed) for how to choose
   reviewers.
 
-  5. Address any reviewer feedback:
+  6. Address any reviewer feedback:
      ~~~~~ bash
      # Make changes, build locally, run tests locally
      git commit -am "Fixed X and Y"
      git cl upload
      ~~~~~
 
-  6. Once the reviewer LGTMs (approves) the patch, ask them to put it into the
+  7. Once the reviewer LGTMs (approves) the patch, ask them to put it into the
   commit queue.
 
 **NOTICE:** On Windows, you'll need to run the above in a Git bash shell in order


### PR DESCRIPTION
#### What is this PR doing?

Adding some info about how bug entries are well-formed in commit message. I got an error because a bogus bug entry for CL at https://webrtc-review.googlesource.com/c/src/+/97421. I thought It was worth adding this info.