### PR TITLE
Add RTP header extension for color space information

### DIFF
--- a/experiments/rtp-hdrext/color-space/index.md
+++ b/experiments/rtp-hdrext/color-space/index.md
@@ -8,11 +8,15 @@ The color space extension is used to communicate color space information and
 optionally also metadata that is needed in order to properly render a high
 dynamic range (HDR) video stream. Contact <kron@google.com> for more info.
 
-Name: "Color space" ; "RTP Header Extension for color space"
+**Name:** "Color space" ; "RTP Header Extension for color space"
 
-Formal name: <http://www.webrtc.org/experiments/rtp-hdrext/color-space>
+**Formal name:** <http://www.webrtc.org/experiments/rtp-hdrext/color-space>
 
-Wire format: 2-byte header + 4 or 30 bytes of data.
+**Status:** Draft
+
+## RTP header extension format
+
+Wire format: 1-byte header + 4 bytes of data or 2-byte header + 30 bytes of data.
 
 The data is written in the following order,
 Color space information (4 bytes):
@@ -46,6 +50,6 @@ Note, the byte order for all integers is big endian.
 
 See the standard SMPTE ST 2086 for more information about these entities.
 
-Notes: Extension shoud be present only in the last packet of video frames. If attached to other packets it should b
-e ignored.
+Notes: Extension shoud be present only in the last packet of video frames. If attached
+to other packets it should be ignored.
 

--- a/experiments/rtp-hdrext/color-space/index.md
+++ b/experiments/rtp-hdrext/color-space/index.md
@@ -38,7 +38,7 @@ Mastering metadata (22 bytes):
   * X and Y coordinate of the white point, scaled by a factor of 10000 and each written
     as 16-bit unsigned integers.
 
-Followed by max light levels (4 bytes)):
+Followed by max light levels (4 bytes):
   * Max content light level, written as a 16-bit unsigned integer.
   * Max frame average light level, written as a 16-bit unsigned integer.
 

--- a/experiments/rtp-hdrext/color-space/index.md
+++ b/experiments/rtp-hdrext/color-space/index.md
@@ -12,7 +12,9 @@ dynamic range (HDR) video stream. Contact <kron@google.com> for more info.
 
 **Formal name:** <http://www.webrtc.org/experiments/rtp-hdrext/color-space>
 
-**Status:** Draft
+**Status:** This extension is defined here to allow for experimentation. Once experience
+has shown that it is useful, we intend to make a proposal based on it for standardization
+in the IETF.
 
 ## RTP header extension format
 

--- a/experiments/rtp-hdrext/color-space/index.md
+++ b/experiments/rtp-hdrext/color-space/index.md
@@ -45,3 +45,7 @@ Followed by max light levels (4 bytes):
 Note, the byte order for all integers is big endian.
 
 See the standard SMPTE ST 2086 for more information about these entities.
+
+Notes: Extension shoud be present only in the last packet of video frames. If attached to other packets it should b
+e ignored.
+

--- a/experiments/rtp-hdrext/color-space/index.md
+++ b/experiments/rtp-hdrext/color-space/index.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: color-space
+permalink: /experiments/rtp-hdrext/color-space/
+---
+
+The color space extension is used to communicate color space information and
+optionally also metadata that is needed in order to properly render a high
+dynamic range (HDR) video stream. Contact <kron@google.com> for more info.
+
+Name: "Color space" ; "RTP Header Extension for color space"
+
+Formal name: <http://www.webrtc.org/experiments/rtp-hdrext/color-space>
+
+Wire format: 2-byte header + 4 or 30 bytes of data.
+
+The data is written in the following order,
+Color space information (4 bytes):
+  * Color primaries value according to ITU-T H.273 Table 2.
+  * Transfer characteristic value according to ITU-T H.273 Table 3.
+  * Matrix coefficients value according to ITU-T H.273 Table 4.
+  * Range value as specified at
+    https://www.webmproject.org/docs/container/#colour.
+
+The extension may optionally include HDR metadata written in the following
+order,
+Mastering metadata (22 bytes):
+  * Luminance max, scaled by a factor of 100 and written as a 24-bit unsigned
+    interger.
+  * Luminance min, scaled by a factor of 10000 and written as a 24-bit unsigned
+    integer.
+  * X and Y coordinate of the primary red, scaled by a factor of 10000 and each written
+    as 16-bit unsigned integers.
+  * X and Y coordinate of the primary green, scaled by a factor of 10000 and each written
+    as 16-bit unsigned integers.
+  * X and Y coordinate of the primary blue, scaled by a factor of 10000 and each written
+    as 16-bit unsigned integers.
+  * X and Y coordinate of the white point, scaled by a factor of 10000 and each written
+    as 16-bit unsigned integers.
+
+Followed by max light levels (4 bytes)):
+  * Max content light level, written as a 16-bit unsigned integer.
+  * Max frame average light level, written as a 16-bit unsigned integer.
+
+Note, the byte order for all integers is big endian.
+
+See the standard SMPTE ST 2086 for more information about these entities.

--- a/experiments/rtp-hdrext/index.md
+++ b/experiments/rtp-hdrext/index.md
@@ -11,5 +11,6 @@ permalink: /experiments/rtp-hdrext/
 Underneath this page, RTP header extensions are listed.
 
   * [abs-send-time](abs-send-time)
+  * [color-space](color-space)
   * [video-content-type](video-content-type)
   * [video-timing](video-timing)


### PR DESCRIPTION
This extension will be used to send explicit color space information.