### PR TITLE
appear.in has been renamed Whereby.

### DIFF
--- a/start/index.md
+++ b/start/index.md
@@ -97,7 +97,7 @@ More resources below.
 * Comprehensive list in the [webrtcHacks article about JavaScript libraries](https://webrtchacks.com/whats-in-a-webrtc-javascript-library/).
 
 #### Video chat
-* [appear.in](https://appear.in/)
+* [Whereby (formerly appear.in)](https://whereby.com/)
 * [SimpleWebRTC](https://github.com/henrikjoreteg/SimpleWebRTC)
 * [easyRTC](https://github.com/priologic/easyrtc)
 * [LyteSpark](http://lytespark.com)


### PR DESCRIPTION
More info: https://whereby.com/information/brand

Not sure if the (formerly) is needed at all. But there's still a lot of "x doesn't work on appear.in" and other text in places, so that's why I put it there. :)