### PR TITLE
Remove iOS/Android pre-built instructions

### DIFF
--- a/native-code/android/index.md
+++ b/native-code/android/index.md
@@ -7,29 +7,6 @@ permalink: /native-code/android/
 
 {% include toc-hide.html %}
 
-
-### Prebuilt libraries
-The easiest way to get started is using the [official prebuilt libraries][5]
-available at JCenter. These libraries are compiled from the tip-of-tree and are
-meant for development purposes only.
-
-On Android Studio 3 add to your dependencies:
-
-~~~~~
-implementation 'org.webrtc:google-webrtc:1.0.+'
-~~~~~
-
-On Android Studio 2 add to your dependencies:
-
-~~~~~
-compile 'org.webrtc:google-webrtc:1.0.+'
-~~~~~
-
-The version of the library is `1.0.<Cr-Commit-Position>`. The hash of the commit
-can be found in the .pom-file. The third party licenses can be found in the
-THIRD_PARTY_LICENSES.md file next to the .aar-file.
-
-
 ### Getting the Code
 
 Android development is only supported on Linux.

--- a/native-code/ios/index.md
+++ b/native-code/ios/index.md
@@ -8,29 +8,6 @@ crumb: iOS
 
 {% include toc-hide.html %}
 
-### Using Cocoapods
-
-The WebRTC framework  is published on [cocoapods.org][1].
-The framework is built from tip-of-tree.
-
-_NOTICE_: The pod version of the framework doesn't support bitcode currently.
-If you need bitcode support, you'll need to manually build the framework.
-The process is described in detail in the following sections.
-
-To integrate it into your project add the following lines to your Podfile
-
-~~~~
-source 'https://github.com/CocoaPods/Specs.git'
-target 'YOUR_APPLICATION_TARGET_NAME_HERE' do
-  platform :ios, '9.0'
-  pod 'GoogleWebRTC'
-end
-~~~~
-
-The versioning system used is *1.1.cr-commit-position*, where *cr-commit-position* can
-be used to identify the exact WebRTC revision the pod was built from. You can check the
-revision at crrev.com/CR_COMMIT_POSITION_HERE.
-
 ### Development Environment
 
 In case you need to build the framework manually


### PR DESCRIPTION
These are no longer being updated. The last uploaded version
is vulnerable to CVE-2020-6514