### PR TITLE
Add link to libilbc project on iLBC page

### DIFF
--- a/license/ilbc-freeware/index.md
+++ b/license/ilbc-freeware/index.md
@@ -10,8 +10,8 @@ crumb: iLBC Freeware
 
 
 
-Global IP Solutions, the creator of iLBC, was acquired by Google in January
-2011. Google continues to support the iLBC effort and is offering it as part
+Global IP Solutions, the creator of iLBC, was acquired by Google in
+January 2011. Google continues to support the iLBC effort and is offering it as part
 of it's WebRTC open source effort. iLBC is now available under the same
 [license]({{ site.baseurl }}/license/) as the WebRTC project. On this page,
 you will find material taken from the old ilbcfreeware.org page.
@@ -51,3 +51,6 @@ in connection with lost or delayed IP packets.
 
 Please read on how you can get the source code and contribute to the code by
 reading the [build]({{ site.baseurl }}/native-code/development/) information.
+
+A third party-maintained "[libilbc](https://github.com/TimothyGu/libilbc)"
+project is also available for direct integrationg with the iLBC codec.


### PR DESCRIPTION
Hi, I'm the maintainer of the [libilbc](https://github.com/TimothyGu/libilbc) library, which essentially extracts out the parts of WebRTC needed to support a standalone iLBC codec. It's used by [FFmpeg](https://ffmpeg.org/) and is packaged by [Homebrew](https://formulae.brew.sh/formula/libilbc#default), [Arch Linux](https://www.archlinux.org/packages/community/x86_64/libilbc/), [Gentoo](https://packages.gentoo.org/packages/media-libs/libilbc), and a few other Linux distros. It would be nice if you could include a link to the project on the webpage. (I understand that this repo is deprecated, but this page seems to be the only official Google reference to iLBC.) Thanks!